### PR TITLE
Fix mime-types-data dependency for TravisCI in ruby 1.9.3

### DIFF
--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails'
 
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
+  spec.add_development_dependency 'mime-types-data', '< 3'
 end
 

--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails'
 
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
-  spec.add_development_dependency 'mime-types-data', '< 3'
+  spec.add_development_dependency 'mime-types', '~> 2.6'
 end
 


### PR DESCRIPTION
I think this should fix the ruby 1.9.3 issue on CI