### PR TITLE
Submission should fails on second attempt under the timestamp_thresho…

### DIFF
--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'test-unit', '~> 3.0'
   spec.add_development_dependency 'mime-types', '< 3.0'
+  spec.add_development_dependency "byebug" if RUBY_VERSION.to_i >= 2
 end
 

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -16,6 +16,7 @@ module InvisibleCaptcha
 
     def detect_spam(options = {})
       if invisible_captcha_timestamp?(options)
+        session[:invisible_captcha_timestamp] = nil
         on_timestamp_spam_action(options)
       elsif invisible_captcha?(options)
         on_spam_action(options)

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -43,6 +43,19 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
       expect(flash[:error]).to eq(InvisibleCaptcha.timestamp_error_message)
     end
 
+    it 'fails on second attempt under the timestamp_threshold in the same session' do
+      request.env['HTTP_REFERER'] = 'http://test.host/topics'
+      post :create, topic: { title: 'foo' }
+      expect(flash[:error]).to be_present
+
+      # second attempt
+      sleep(0.8)
+      flash[:error] = nil
+      session[:invisible_captcha_timestamp] ||= Time.zone.now.iso8601
+      post :create, topic: { title: 'foo' }
+      expect(flash[:error]).to be_present
+    end
+
     it 'allow custom on_timestamp_spam callback' do
       put :update, id: 1, topic: { title: 'bar' }
 


### PR DESCRIPTION
…ld in the same session. So, reset the invisible_captcha_timestamp on each submission under the threshold.

More info: #24 