### PR TITLE
Improves visual honeypots css

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ $ gem install invisible_captcha
 
 ## Usage
 
-View code:
+**View code for styles:**
+
+```erb
+<head>
+ ...
+  <%= invisible_captcha_styles %>
+</head>
+```
+
+This method adds the styles that hide the honeypot field from regular users.
+
+**View code in form:**
 
 ```erb
 <%= form_for(@topic) do |f| %>
@@ -42,7 +53,7 @@ View code:
 <% end %>
 ```
 
-Controller code:
+**Controller code:**
 
 ```ruby
 class TopicsController < ApplicationController
@@ -121,7 +132,10 @@ The `invisible_captcha` method accepts some options:
 
 ### View helpers options:
 
-Using the view/form helper you can override some defaults for the given instance. Actually, it allows to change: `sentence_for_humans` and `visual_honeypots`.
+Using the view/form helper you can override some defaults for the given instance.
+It allows to change:
+
+**Visibility options:** `sentence_for_humans` and `visual_honeypots`.
 
 ```erb
 <%= form_for(@topic) do |f| %>
@@ -130,6 +144,15 @@ Using the view/form helper you can override some defaults for the given instance
   <%= invisible_captcha visual_honeypots: true, sentence_for_humans: "Ei, don't fill on this input!" %>
 <% end %>
 ```
+
+**CSS option:** `style_class_name` (by default a random name is generated):
+
+```erb
+<%= form_for(@topic) do |f| %>
+  <%= f.invisible_captcha :subtitle, style_class_name: "subtitle-honeypot" %>
+<% end %>
+```
+
 
 ### I18n
 

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -22,7 +22,7 @@ module InvisibleCaptcha
 
       honeypot = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
       label    = options[:sentence_for_humans] || InvisibleCaptcha.sentence_for_humans
-      visual_honeypots = options[:visual_honeypots] || InvisibleCaptcha.visual_honeypots
+      visual_honeypots = options[:visual_honeypots].nil? ? InvisibleCaptcha.visual_honeypots : options[:visual_honeypots]
       inline_style = visual_honeypots ? "" : "display: none;"
 
       html_id  = generate_html_id(honeypot, scope)

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -22,10 +22,12 @@ module InvisibleCaptcha
 
       honeypot = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
       label    = options[:sentence_for_humans] || InvisibleCaptcha.sentence_for_humans
+      visual_honeypots = options[:visual_honeypots] || InvisibleCaptcha.visual_honeypots
+      inline_style = visual_honeypots ? "" : "display: none;"
+
       html_id  = generate_html_id(honeypot, scope)
 
-      content_tag(:div, :id => html_id) do
-        concat visibility_css(html_id, options)
+      content_tag(:div, :id => html_id, style: inline_style) do
         concat label_tag(build_label_name(honeypot, scope), label)
         concat text_field_tag(build_text_field_name(honeypot, scope))
       end
@@ -33,18 +35,6 @@ module InvisibleCaptcha
 
     def generate_html_id(honeypot, scope = nil)
       "#{scope || honeypot}_#{Time.zone.now.to_i}"
-    end
-
-    def visibility_css(container_id, options)
-      visibility = if options.key?(:visual_honeypots)
-        options[:visual_honeypots]
-      else
-        InvisibleCaptcha.visual_honeypots
-      end
-
-      content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => 'scoped') do
-        "##{container_id} { display:none; }" unless visibility
-      end
     end
 
     def build_label_name(honeypot, scope = nil)

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -12,6 +12,11 @@ module InvisibleCaptcha
       build_invisible_captcha(honeypot, scope, options)
     end
 
+    # Adds the honeypot styles to hide the invisible captcha field
+    def invisible_captcha_styles
+      content_for(:invisible_captcha_styles) if content_for?(:invisible_captcha_styles)
+    end
+
     private
 
     def build_invisible_captcha(honeypot = nil, scope = nil, options = {})
@@ -23,11 +28,13 @@ module InvisibleCaptcha
       honeypot = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
       label    = options[:sentence_for_humans] || InvisibleCaptcha.sentence_for_humans
       visual_honeypots = options[:visual_honeypots].nil? ? InvisibleCaptcha.visual_honeypots : options[:visual_honeypots]
-      inline_style = visual_honeypots ? "" : "display: none;"
+      @style_class = options[:style_class_name].presence
 
       html_id  = generate_html_id(honeypot, scope)
 
-      content_tag(:div, :id => html_id, style: inline_style) do
+      add_styles unless visual_honeypots
+
+      content_tag(:div, id: html_id, class: invisible_captcha_style_class) do
         concat label_tag(build_label_name(honeypot, scope), label)
         concat text_field_tag(build_text_field_name(honeypot, scope))
       end
@@ -51,6 +58,20 @@ module InvisibleCaptcha
       else
         honeypot
       end
+    end
+
+    def add_styles
+      provide(:invisible_captcha_styles) do
+        content_tag(:style, ".#{invisible_captcha_style_class} {display:none;}")
+      end if @view_flow.present?
+    end
+
+    def invisible_captcha_style_class
+      @style_class ||= invisible_captcha_dynamic_style_class
+    end
+
+    def invisible_captcha_dynamic_style_class
+      "abcdefghijkl-mnopqrstuvwxyz".chars.sample((10..33).to_a.sample).join
     end
   end
 end

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -12,7 +12,7 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
   context 'without invisible_captcha_timestamp in session' do
     it 'fails like if it was submitted too fast' do
       request.env['HTTP_REFERER'] = 'http://test.host/topics'
-      post :create, topic: { title: 'foo' }
+      post :create, params: { topic: { title: 'foo' } }
 
       expect(response).to redirect_to :back
       expect(flash[:error]).to eq(InvisibleCaptcha.timestamp_error_message)
@@ -23,7 +23,7 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
     it 'does not fail like if it was submitted too fast' do
       request.env['HTTP_REFERER'] = 'http://test.host/topics'
       InvisibleCaptcha.timestamp_enabled = false
-      post :create, topic: { title: 'foo' }
+      post :create, params: { topic: { title: 'foo' } }
 
       expect(flash[:error]).not_to be_present
       expect(response.body).to be_present
@@ -37,14 +37,14 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
 
     it 'fails if submission before timestamp_threshold' do
       request.env['HTTP_REFERER'] = 'http://test.host/topics'
-      post :create, topic: { title: 'foo' }
+      post :create, params: { topic: { title: 'foo' } }
 
       expect(response).to redirect_to :back
       expect(flash[:error]).to eq(InvisibleCaptcha.timestamp_error_message)
     end
 
     it 'allow custom on_timestamp_spam callback' do
-      put :update, id: 1, topic: { title: 'bar' }
+      put :update, params: { id: 1, topic: { title: 'bar' } }
 
       expect(response).to redirect_to(root_path)
     end
@@ -53,7 +53,7 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
       it 'passes if submission on or after timestamp_threshold' do
         sleep InvisibleCaptcha.timestamp_threshold
 
-        post :create, topic: { title: 'foo' }
+        post :create, params: { topic: { title: 'foo' } }
 
         expect(flash[:error]).not_to be_present
         expect(response.body).to be_present
@@ -62,11 +62,26 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
       it 'allow to set a custom timestamp_threshold per action' do
         sleep 2 # custom threshold
 
-        post :publish, id: 1
+        post :publish, params: { id: 1 }
 
         expect(flash[:error]).not_to be_present
         expect(response.body).to be_present
       end
+    end
+  end
+
+  context 'styles' do
+    it 'adds hidding styles by default' do
+      allow_any_instance_of(InvisibleCaptcha::ViewHelpers).to receive(:invisible_captcha_dynamic_style_class).and_return('test')
+      get :new
+
+      expect(response.body.include?('<style>.test {display:none;}</style>')).to eq(true)
+    end
+
+    it 'does not add styles in visual_honeypots context' do
+      get :new, params: { context: 'visual_honeypots' }
+
+      expect(response.body.include?('<style>')).to eq(false)
     end
   end
 
@@ -78,19 +93,19 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
     end
 
     it 'fails with spam' do
-      post :create, topic: { subtitle: 'foo' }
+      post :create, params: { topic: { subtitle: 'foo' } }
 
       expect(response.body).to be_blank
     end
 
     it 'passes with no spam' do
-      post :create, topic: { title: 'foo' }
+      post :create, params: { topic: { title: 'foo' } }
 
       expect(response.body).to be_present
     end
 
     it 'allow custom on_spam callback' do
-      put :update, id: 1, topic: { subtitle: 'foo' }
+      put :update, params: { id: 1, topic: { subtitle: 'foo' } }
 
       expect(response.body).to redirect_to(new_topic_path)
     end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
+  <%= invisible_captcha_styles %>
 </head>
 <body>
 

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -6,26 +6,19 @@ describe InvisibleCaptcha::ViewHelpers, type: :helper do
     input_id   = build_label_name(honeypot, scope)
     input_name = build_text_field_name(honeypot, scope)
     html_id    = generate_html_id(honeypot, scope)
-    visibilty  = if options.key?(:visual_honeypots)
-      options[:visual_honeypots]
-    else
+    visibilty  = if options[:visual_honeypots].nil?
       InvisibleCaptcha.visual_honeypots
-    end
-    style_attributes, input_attributes = if Gem::Version.new(Rails.version) > Gem::Version.new("4.2.0")
-      [
-        'type="text/css" media="screen" scoped="scoped"',
-        "type=\"text\" name=\"#{input_name}\" id=\"#{input_id}\""
-      ]
     else
-      [
-        'media="screen" scoped="scoped" type="text/css"',
-        "id=\"#{input_id}\" name=\"#{input_name}\" type=\"text\""
-      ]
+      options[:visual_honeypots]
+    end
+    input_attributes = if Gem::Version.new(Rails.version) > Gem::Version.new("4.2.0")
+      "type=\"text\" name=\"#{input_name}\" id=\"#{input_id}\""
+    else
+      "id=\"#{input_id}\" name=\"#{input_name}\" type=\"text\""
     end
 
     %{
-      <div id="#{html_id}">
-        <style #{style_attributes}>#{visibilty ? '' : "##{html_id} { display:none; }"}</style>
+      <div id="#{html_id}" style="#{visibilty ? nil : 'display: none;'}">
         <label for="#{input_id}">#{InvisibleCaptcha.sentence_for_humans}</label>
         <input #{input_attributes} />
       </div>

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -6,6 +6,7 @@ describe InvisibleCaptcha::ViewHelpers, type: :helper do
     input_id   = build_label_name(honeypot, scope)
     input_name = build_text_field_name(honeypot, scope)
     html_id    = generate_html_id(honeypot, scope)
+    html_class = options[:style_class_name] || invisible_captcha_style_class
     visibilty  = if options[:visual_honeypots].nil?
       InvisibleCaptcha.visual_honeypots
     else
@@ -18,7 +19,7 @@ describe InvisibleCaptcha::ViewHelpers, type: :helper do
     end
 
     %{
-      <div id="#{html_id}" style="#{visibilty ? nil : 'display: none;'}">
+      <div id="#{html_id}" class="#{html_class}">
         <label for="#{input_id}">#{InvisibleCaptcha.sentence_for_humans}</label>
         <input #{input_attributes} />
       </div>
@@ -42,6 +43,10 @@ describe InvisibleCaptcha::ViewHelpers, type: :helper do
 
   it 'with specific honeypot and scope' do
     expect(invisible_captcha(:subtitle, :topic)).to eq(helper_output(:subtitle, :topic))
+  end
+
+  it 'with specific style class name' do
+    expect(invisible_captcha(style_class_name: "test_class")).to match(/class="test_class"/)
   end
 
   context "honeypot visibilty" do


### PR DESCRIPTION
This PR changes the `<style>` tag to a inline style in the container `<div>` of invisible captcha fields if visual honeypots it's set to false.

```
<div style="display: none;">
  <%= f.invisible_captcha :something %>
</div>
```

This avoid the HTML error validation:

`Element <style> not allowed as child of element div in this context.`

😊