### PR TITLE
Change honeypot to check for key presence.

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -77,7 +77,7 @@ module InvisibleCaptcha
         # If honeypot is presented, search for:
         # - honeypot: params[:subtitle]
         # - honeypot with scope: params[:topic][:subtitle]
-        if params[honeypot].present? || (params[scope] && params[scope][honeypot].present?)
+        if params.has_key?(honeypot) || (params[scope] && params[scope].has_key?(honeypot))
           return true
         end
       else

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -99,6 +99,18 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
       expect(response.body).to be_blank
     end
 
+    it 'fails with present spam key but empty value' do
+      switchable_post :create, topic: { subtitle: '' }
+
+      expect(response.body).to be_blank
+    end
+
+    it 'fails with present spam key but nil value' do
+      switchable_post :create, topic: { subtitle: nil }
+
+      expect(response.body).to be_blank
+    end
+
     it 'passes with no spam' do
       switchable_post :create, topic: { title: 'foo' }
 


### PR DESCRIPTION
Browsers appear to do a pretty good job of not adding form inputs that
are `display:none` to the request at all. Some bots however, will
include the honeypot with no value.

Previously, this would pass the `invisible_captcha?` check, but could
fail in the controller for people using
`ActionController::StrongParameters`, which fails on presence of key in
the `params` hash. Now `invisible_captcha?` triggers if the honeypot
exists as a key in `params`.

I tested this by verifying that empty and `nil` values for the honeypot
fail to trigger `invisible_captcha?`, then fixed it so the tests passed.