### PR TITLE
Next release v0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ sudo: false
 
 rvm:
   - ruby-head
-  - 2.4
-  - 2.3
-  - 2.2
-  - 2.1
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8
+  - 2.1.10
 
 gemfile:
   - gemfiles/rails_5.1.gemfile
@@ -20,13 +20,13 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 2.1
+    - rvm: 2.1.10
       gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: 2.1
+    - rvm: 2.1.10
       gemfile: gemfiles/rails_5.1.gemfile
-    - rvm: 2.4
+    - rvm: 2.4.2
       gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: 2.4
+    - rvm: 2.4.2
       gemfile: gemfiles/rails_3.2.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_3.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ sudo: false
 
 rvm:
   - ruby-head
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
+  - 2.4
+  - 2.3
+  - 2.2
   - 2.1
-  - 1.9.3
 
 gemfile:
   - gemfiles/rails_5.1.gemfile
@@ -21,19 +20,13 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails_4.2.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails_5.1.gemfile
     - rvm: 2.1
       gemfile: gemfiles/rails_5.0.gemfile
     - rvm: 2.1
       gemfile: gemfiles/rails_5.1.gemfile
-    - rvm: 2.4.1
+    - rvm: 2.4
       gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: 2.4.1
+    - rvm: 2.4
       gemfile: gemfiles/rails_3.2.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_3.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,18 @@
 language: ruby
-
 cache: bundler
-
 sudo: false
-
 rvm:
   - ruby-head
   - 2.4.2
   - 2.3.5
   - 2.2.8
   - 2.1.10
-
 gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_3.2.gemfile
-
 matrix:
   exclude:
     - rvm: 2.1.10
@@ -28,6 +23,8 @@ matrix:
       gemfile: gemfiles/rails_4.1.gemfile
     - rvm: 2.4.2
       gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_4.1.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_3.2.gemfile
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Invisible Captcha provides different techniques to protect your application against spambots.
 
-The main protection is a solution based on the `honeypot` strategy. It provides a better user experience, since there is no extra steps for the real users.
+The main protection is a solution based on the `honeypot` principle, which provides a better user experience, since there is no extra steps for real users, but for the bots.
 
-**Background**
+**Strategy**
 
-The technique consists on adding an input field into the form that:
+Essentially, consists on adding an input field into the form that:
 
 * shouldn't be visible by the real users
 * should be left empty by the real users
@@ -91,20 +91,23 @@ This section contains a description of all plugin options and customizations.
 You can customize:
 
 * `sentence_for_humans`: text for real users if input field was visible. By default, it uses I18n (see below).
-* `honeypots`: collection of default honeypots. Used by the view helper, called with no args, to generate a random honeypot field name.
+* `honeypots`: collection of default honeypots. Used by the view helper, called with no args, to generate a random honeypot field name. By default, a random collection is already generated.
 * `visual_honeypots`: make honeypots visible, also useful to test/debug your implementation.
 * `timestamp_threshold`: fastest time (in seconds) to expect a human to submit the form (see [original article by Yoav Aner](http://blog.gingerlime.com/2012/simple-detection-of-comment-spam-in-rails/) outlining the idea). By default, 4 seconds. **NOTE:** It's recommended to deactivate the autocomplete feature to avoid false positives (`autocomplete="off"`).
 * `timestamp_enabled`: option to disable the time threshold check at application level. Could be useful, for example, on some testing scenarios. By default, true.
 * `timestamp_error_message`: flash error message thrown when form submitted quicker than the `timestamp_threshold` value. It uses I18n by default.
+* `injectable_styles`: if enabled, you should call anywhere in your layout the following helper `<%= invisible_captcha_styles %>`. This allows you to inject styles, for example, in `<head>`. False by default, styles are injected inline with the honeypot.
 
 To change these defaults, add the following to an initializer (recommended `config/initializers/invisible_captcha.rb`):
 
 ```ruby
 InvisibleCaptcha.setup do |config|
-  config.honeypots           << 'another_fake_attribute'
-  config.visual_honeypots    = false
-  config.timestamp_threshold = 4
-  config.timestamp_enabled   = true
+  # config.honeypots           << ['more', 'fake', 'attribute', 'names']
+  # config.visual_honeypots    = false
+  # config.timestamp_threshold = 4
+  # config.timestamp_enabled   = true
+  # config.injectable_styles   = false
+
   # Leave these unset if you want to use I18n (see below)
   # config.sentence_for_humans     = 'If you are a human, ignore this field'
   # config.timestamp_error_message = 'Sorry, that was too quick! Please resubmit.'
@@ -134,6 +137,12 @@ Using the view/form helper you can override some defaults for the given instance
   <!-- or -->
   <%= invisible_captcha visual_honeypots: true, sentence_for_humans: "Ei, don't fill on this input!" %>
 <% end %>
+```
+
+You can also pass html options to the input:
+
+```erb
+<%= invisible_captcha :subtitle, :topic, id: "your_id", class: "your_class" %>
 ```
 
 ### I18n

--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ Invisible Captcha provides different techniques to protect your application agai
 
 The main protection is a solution based on the `honeypot` principle, which provides a better user experience, since there is no extra steps for real users, but for the bots.
 
-**Strategy**
-
-Essentially, consists on adding an input field into the form that:
+Essentially, the strategy consists on adding an input field :honey_pot: into the form that:
 
 * shouldn't be visible by the real users
 * should be left empty by the real users
 * will most be filled by spam bots
 
-It also comes with a time-sensitive form submission.
+It also comes with a time-sensitive :hourglass: form submission.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@
 
 > Simple and flexible spam protection solution for Rails applications.
 
-It is based on the `honeypot` strategy to provide a better user experience. It also provides a time-sensitive form submission.
+Invisible Captcha provides different techniques to protect your application against spambots.
+
+The main protection is a solution based on the `honeypot` strategy. It provides a better user experience, since there is no extra steps for the real users.
 
 **Background**
 
-The strategy is about adding an input field into the form that:
+The technique consists on adding an input field into the form that:
 
 * shouldn't be visible by the real users
 * should be left empty by the real users
 * will most be filled by spam bots
+
+It also comes with a time-sensitive form submission.
 
 ## Installation
 
@@ -116,6 +120,7 @@ The `invisible_captcha` method accepts some options:
 * `honeypot`: name of honeypot.
 * `scope`: name of scope, ie: 'topic[subtitle]' -> 'topic' is the scope.
 * `on_spam`: custom callback to be called on spam detection.
+* `timestamp_threshold`: enable/disable this technique at action level.
 * `on_timestamp_spam`: custom callback to be called when form submitted too quickly. The default action redirects to `:back` printing a warning in `flash[:error]`.
 * `timestamp_threshold`: custom threshold per controller/action. Overrides the global value for `InvisibleCaptcha.timestamp_threshold`.
 
@@ -165,6 +170,8 @@ Run the test suite against all supported versions:
 ```
 $ bundle exec appraisal rake
 ```
+
+### Demo
 
 Start a sample Rails app ([source code](spec/dummy)) with `InvisibleCaptcha` integrated:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ class TopicsController < ApplicationController
 end
 ```
 
-Note that isn't mandatory to specify a `honeypot` attribute (nor in the view, nor in the controller). In this case, the engine will take a random field from `InvisibleCaptcha.honeypots`. So, if you're integrating it following this path, in your form:
+Note that is not mandatory to specify a `honeypot` attribute (nor in the view, nor in the controller). In this case, the engine will take a random field from `InvisibleCaptcha.honeypots`. So, if you're integrating it following this path, in your form:
 
 ```erb
 <%= form_tag(new_contact_path) do |f| %>
@@ -118,7 +118,7 @@ The `invisible_captcha` method accepts some options:
 
 * `only`: apply to given controller actions.
 * `except`: exclude to given controller actions.
-* `honeypot`: name of honeypot.
+* `honeypot`: name of custom honeypot.
 * `scope`: name of scope, ie: 'topic[subtitle]' -> 'topic' is the scope.
 * `on_spam`: custom callback to be called on spam detection.
 * `timestamp_threshold`: enable/disable this technique at action level.
@@ -175,7 +175,8 @@ $ bundle exec rspec
 Run the test suite against all supported versions:
 
 ```
-$ bundle exec appraisal rake
+$ bundle exec appraisal install
+$ bundle exec appraisal rspec
 ```
 
 ### Demo

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It also comes with a time-sensitive form submission.
 
 ## Installation
 
-Invisible Captcha is tested against Rails `>= 3.2` and Ruby `>= 1.9.3`.
+Invisible Captcha is tested against Rails `>= 3.2` and Ruby `>= 2.1`.
 
 Add this line to you Gemfile:
 
@@ -133,9 +133,9 @@ Using the view/form helper you can override some defaults for the given instance
 
 ```erb
 <%= form_for(@topic) do |f| %>
-  <%= f.invisible_captcha :subtitle, visual_honeypots: true, sentence_for_humans: "Ei, don't fill on this input!" %>
+  <%= f.invisible_captcha :subtitle, visual_honeypots: true, sentence_for_humans: "hey! leave this input empty!" %>
   <!-- or -->
-  <%= invisible_captcha visual_honeypots: true, sentence_for_humans: "Ei, don't fill on this input!" %>
+  <%= invisible_captcha visual_honeypots: true, sentence_for_humans: "hey! leave this input empty!" %>
 <% end %>
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,5 +13,5 @@ task :web do
   puts "Starting application in http://localhost:#{port} ... \n"
 
   Dir.chdir(app_path)
-  `rails s -p #{port}`
+  exec("rails s -p #{port}")
 end

--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'test-unit', '~> 3.0'
-  spec.add_development_dependency 'mime-types', '< 3.0'
   spec.add_development_dependency 'byebug'
 end
 

--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'test-unit', '~> 3.0'
   spec.add_development_dependency 'mime-types', '< 3.0'
+  spec.add_development_dependency 'byebug' if RUBY_VERSION.to_i >= 2
 end
 

--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'test-unit', '~> 3.0'
   spec.add_development_dependency 'mime-types', '< 3.0'
-  spec.add_development_dependency 'byebug' if RUBY_VERSION.to_i >= 2
+  spec.add_development_dependency 'byebug'
 end
 

--- a/lib/invisible_captcha.rb
+++ b/lib/invisible_captcha.rb
@@ -60,6 +60,14 @@ module InvisibleCaptcha
       honeypots.sample
     end
 
+    def css_strategy
+      [
+        "display:none;",
+        "position:absolute!important;top:-9999px;left:-9999px;",
+        "position:absolute!important;height:1px;width:1px;overflow:hidden;"
+      ].sample
+    end
+
     private
 
     def call_lambda_or_return(obj)

--- a/lib/invisible_captcha.rb
+++ b/lib/invisible_captcha.rb
@@ -7,43 +7,37 @@ require 'invisible_captcha/railtie'
 module InvisibleCaptcha
   class << self
     attr_writer :sentence_for_humans,
-                :timestamp_error_message,
-                :error_message
+                :timestamp_error_message
 
     attr_accessor :honeypots,
                   :timestamp_threshold,
                   :timestamp_enabled,
-                  :visual_honeypots
+                  :visual_honeypots,
+                  :injectable_styles
 
     def init!
       # Default sentence for real users if text field was visible
       self.sentence_for_humans = -> { I18n.t('invisible_captcha.sentence_for_humans', default: 'If you are a human, ignore this field') }
 
-      # Default error message for validator
-      self.error_message = -> { I18n.t('invisible_captcha.error_message', default: 'You are a robot!') }
-
-      # Default fake fields for controller based workflow
-      self.honeypots = ['foo_id', 'bar_id', 'baz_id']
+      # Timestamp check enabled by default
+      self.timestamp_enabled = true
 
       # Fastest time (in seconds) to expect a human to submit the form
       self.timestamp_threshold = 4
-
-      # Timestamp check enabled by default
-      self.timestamp_enabled = true
 
       # Default error message for validator when form submitted too quickly
       self.timestamp_error_message = -> { I18n.t('invisible_captcha.timestamp_error_message', default: 'Sorry, that was too quick! Please resubmit.') }
 
       # Make honeypots visibles
       self.visual_honeypots = false
+
+      # If enabled, you should call anywhere in of your layout the following helper, to inject the honeypot styles:
+      #  <%= invisible_captcha_styles %>
+      self.injectable_styles = false
     end
 
     def sentence_for_humans
       call_lambda_or_return(@sentence_for_humans)
-    end
-
-    def error_message
-      call_lambda_or_return(@error_message)
     end
 
     def timestamp_error_message
@@ -52,6 +46,14 @@ module InvisibleCaptcha
 
     def setup
       yield(self) if block_given?
+    end
+
+    def honeypots
+      @honeypots ||= (1..5).map { generate_random_honeypot }
+    end
+
+    def generate_random_honeypot
+      "abcdefghijkl-mnopqrstuvwxyz".chars.sample(rand(10..20)).join
     end
 
     def get_honeypot

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -15,14 +15,14 @@ module InvisibleCaptcha
     end
 
     def detect_spam(options = {})
-      if invisible_captcha_timestamp?(options)
-        on_timestamp_spam_action(options)
-      elsif invisible_captcha?(options)
-        on_spam_action(options)
+      if timestamp_spam?(options)
+        on_timestamp_spam(options)
+      elsif honeypot_spam?(options)
+        on_spam(options)
       end
     end
 
-    def on_timestamp_spam_action(options = {})
+    def on_timestamp_spam(options = {})
       if action = options[:on_timestamp_spam]
         send(action)
       else
@@ -34,7 +34,7 @@ module InvisibleCaptcha
       end
     end
 
-    def on_spam_action(options = {})
+    def on_spam(options = {})
       if action = options[:on_spam]
         send(action)
       else
@@ -42,7 +42,7 @@ module InvisibleCaptcha
       end
     end
 
-    def invisible_captcha_timestamp?(options = {})
+    def timestamp_spam?(options = {})
       enabled = if options.key?(:timestamp_enabled)
         options[:timestamp_enabled]
       else
@@ -70,7 +70,7 @@ module InvisibleCaptcha
       false
     end
 
-    def invisible_captcha?(options = {})
+    def honeypot_spam?(options = {})
       honeypot = options[:honeypot]
       scope    = options[:scope] || controller_name.singularize
 

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -4,10 +4,11 @@ module InvisibleCaptcha
     #
     # @param honeypot [Symbol] name of honeypot, ie: subtitle => input name: subtitle
     # @param scope [Symbol] name of honeypot scope, ie: topic => input name: topic[subtitle]
+    # @param options [Hash] html_options for input and invisible_captcha options
     # @return [String] the generated html
     def invisible_captcha(honeypot = nil, scope = nil, options = {})
       if InvisibleCaptcha.timestamp_enabled
-        session[:invisible_captcha_timestamp] ||= Time.zone.now.iso8601
+        session[:invisible_captcha_timestamp] = Time.zone.now.iso8601
       end
       build_invisible_captcha(honeypot, scope, options)
     end
@@ -21,13 +22,13 @@ module InvisibleCaptcha
       end
 
       honeypot = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
-      label    = options[:sentence_for_humans] || InvisibleCaptcha.sentence_for_humans
+      label    = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
       html_id  = generate_html_id(honeypot, scope)
 
       content_tag(:div, :id => html_id) do
         concat visibility_css(html_id, options)
         concat label_tag(build_label_name(honeypot, scope), label)
-        concat text_field_tag(build_text_field_name(honeypot, scope))
+        concat text_field_tag(build_text_field_name(honeypot, scope), nil, options)
       end
     end
 
@@ -37,7 +38,7 @@ module InvisibleCaptcha
 
     def visibility_css(container_id, options)
       visibility = if options.key?(:visual_honeypots)
-        options[:visual_honeypots]
+        options.delete(:visual_honeypots)
       else
         InvisibleCaptcha.visual_honeypots
       end

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -41,11 +41,11 @@ module InvisibleCaptcha
       content_tag(:div, class: css_class) do
         concat styles unless InvisibleCaptcha.injectable_styles
         concat label_tag(build_label_name(honeypot, scope), label)
-        concat text_field_tag(build_text_field_name(honeypot, scope), nil, options)
+        concat text_field_tag(build_text_field_name(honeypot, scope), nil, options.merge(tabindex: -1))
       end
     end
 
-    def visibility_css(container_id, options)
+    def visibility_css(css_class, options)
       visible = if options.key?(:visual_honeypots)
         options.delete(:visual_honeypots)
       else
@@ -55,7 +55,7 @@ module InvisibleCaptcha
       return if visible
 
       content_tag(:style, media: 'screen') do
-        ".#{container_id} {display:none;}"
+        ".#{css_class} {display:none;}"
       end
     end
 

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -5,12 +5,19 @@ module InvisibleCaptcha
     # @param honeypot [Symbol] name of honeypot, ie: subtitle => input name: subtitle
     # @param scope [Symbol] name of honeypot scope, ie: topic => input name: topic[subtitle]
     # @param options [Hash] html_options for input and invisible_captcha options
+    #
     # @return [String] the generated html
     def invisible_captcha(honeypot = nil, scope = nil, options = {})
       if InvisibleCaptcha.timestamp_enabled
         session[:invisible_captcha_timestamp] = Time.zone.now.iso8601
       end
       build_invisible_captcha(honeypot, scope, options)
+    end
+
+    def invisible_captcha_styles
+      if content_for?(:invisible_captcha_styles)
+        content_for(:invisible_captcha_styles)
+      end
     end
 
     private
@@ -21,30 +28,34 @@ module InvisibleCaptcha
         honeypot = nil
       end
 
-      honeypot = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
-      label    = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
-      html_id  = generate_html_id(honeypot, scope)
+      honeypot  = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
+      label     = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
+      css_class = "#{honeypot}_#{Time.zone.now.to_i}"
 
-      content_tag(:div, :id => html_id) do
-        concat visibility_css(html_id, options)
+      styles = visibility_css(css_class, options)
+
+      provide(:invisible_captcha_styles) do
+        styles
+      end if InvisibleCaptcha.injectable_styles
+
+      content_tag(:div, class: css_class) do
+        concat styles unless InvisibleCaptcha.injectable_styles
         concat label_tag(build_label_name(honeypot, scope), label)
         concat text_field_tag(build_text_field_name(honeypot, scope), nil, options)
       end
     end
 
-    def generate_html_id(honeypot, scope = nil)
-      "#{scope || honeypot}_#{Time.zone.now.to_i}"
-    end
-
     def visibility_css(container_id, options)
-      visibility = if options.key?(:visual_honeypots)
+      visible = if options.key?(:visual_honeypots)
         options.delete(:visual_honeypots)
       else
         InvisibleCaptcha.visual_honeypots
       end
 
-      content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => 'scoped') do
-        "##{container_id} { display:none; }" unless visibility
+      return if visible
+
+      content_tag(:style, media: 'screen') do
+        ".#{container_id} {display:none;}"
       end
     end
 

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -55,7 +55,7 @@ module InvisibleCaptcha
       return if visible
 
       content_tag(:style, media: 'screen') do
-        ".#{css_class} {display:none;}"
+        ".#{css_class} {#{InvisibleCaptcha.css_strategy}}"
       end
     end
 

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -113,5 +113,12 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
 
       expect(response.body).to redirect_to(new_topic_path)
     end
+
+    it 'honeypot is removed from params if you use a custom honeypot' do
+      switchable_post :create, topic: { title: 'foo', subtitle: '' }
+
+      expect(flash[:error]).not_to be_present
+      expect(@controller.params[:topic].key?(:subtitle)).to eq(false)
+    end
   end
 end

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -22,8 +22,8 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
   before(:each) do
     @controller = TopicsController.new
     request.env['HTTP_REFERER'] = 'http://test.host/topics'
+    InvisibleCaptcha.init!
     InvisibleCaptcha.timestamp_threshold = 1
-    InvisibleCaptcha.timestamp_enabled = true
   end
 
   context 'without invisible_captcha_timestamp in session' do
@@ -62,10 +62,10 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
       expect(flash[:error]).to eq(InvisibleCaptcha.timestamp_error_message)
     end
 
-    it 'allow custom on_timestamp_spam callback' do
+    it 'allow a custom on_timestamp_spam callback' do
       switchable_put :update, id: 1, topic: { title: 'bar' }
 
-      expect(response).to redirect_to(root_path)
+      expect(response.status).to eq(204)
     end
 
     context 'successful submissions' do
@@ -108,7 +108,7 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
       expect(response.body).to be_present
     end
 
-    it 'allow custom on_spam callback' do
+    it 'allow a custom on_spam callback' do
       switchable_put :update, id: 1, topic: { subtitle: 'foo' }
 
       expect(response.body).to redirect_to(new_topic_path)

--- a/spec/dummy/README.md
+++ b/spec/dummy/README.md
@@ -1,3 +1,9 @@
 # Dummy App
 
-Dummy Rails Application to test `Invisible Captcha`. Also used as a demo application to show `Invisible Captcha` in action. You can run it with `bundle exec rake web` from the root of the project.
+Dummy Rails Application to test `Invisible Captcha`.
+
+It's also used as a demo application to show `Invisible Captcha` in action. You can run the app by using the following command, from the root of the project:
+
+    > bundle exec rake web
+
+[« Back to Docs](https://github.com/markets/invisible_captcha#invisible-captcha)

--- a/spec/dummy/README.md
+++ b/spec/dummy/README.md
@@ -1,3 +1,3 @@
 # Dummy App
 
-Dummy Rails Application to test `Invisible Captcha`.
+Dummy Rails Application to test `Invisible Captcha`. Also used as a demo application to show `Invisible Captcha` in action. You can run it with `bundle exec rake web` from the root of the project.

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -1,15 +1,1 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
-//
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// the compiled file.
-//
-// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
-// GO AFTER THE REQUIRES BELOW.
-//
-//= require jquery
-//= require jquery_ujs
-//= require_tree .
+console.log('Hi from Invisible Captcha!');

--- a/spec/dummy/app/assets/stylesheets/application.css
+++ b/spec/dummy/app/assets/stylesheets/application.css
@@ -1,13 +1,14 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the top of the
- * compiled file, but it's generally better to create a new file per style scope.
- *
- *= require_self
- *= require_tree .
- */
+body {
+  background-color: #ccc;
+  margin: 2em;
+}
+
+input,
+textarea {
+  border: 0;
+  margin-bottom: 1.5em;
+}
+
+.errors {
+  color: darkred;
+}

--- a/spec/dummy/app/assets/stylesheets/application.css
+++ b/spec/dummy/app/assets/stylesheets/application.css
@@ -1,12 +1,29 @@
 body {
+  font-family: Arial, Helvetica, sans-serif;
   background-color: #ccc;
   margin: 2em;
+}
+
+h1 {
+  border-bottom: 3px solid;
 }
 
 input,
 textarea {
   border: 0;
   margin-bottom: 1.5em;
+}
+
+input {
+  height: 2em;
+}
+
+button {
+  background-color: #f0f0f0;
+  border-radius: 0.25em;
+  height: 3em;
+  width: 10em;
+  font-size: 1em;
 }
 
 .errors {

--- a/spec/dummy/app/controllers/topics_controller.rb
+++ b/spec/dummy/app/controllers/topics_controller.rb
@@ -1,9 +1,12 @@
 class TopicsController < ApplicationController
   invisible_captcha honeypot: :subtitle, only: :create
+
   invisible_captcha honeypot: :subtitle, only: :update,
                               on_spam: :custom_callback,
                               on_timestamp_spam: :custom_timestamp_callback
+
   invisible_captcha honeypot: :subtitle, only: :publish, timestamp_threshold: 2
+
   invisible_captcha honeypot: :subtitle, only: :copy, timestamp_enabled: false
 
   def index
@@ -48,6 +51,6 @@ class TopicsController < ApplicationController
   end
 
   def custom_timestamp_callback
-    redirect_to root_path
+    head(204)
   end
 end

--- a/spec/dummy/app/controllers/topics_controller.rb
+++ b/spec/dummy/app/controllers/topics_controller.rb
@@ -4,6 +4,11 @@ class TopicsController < ApplicationController
                               on_spam: :custom_callback,
                               on_timestamp_spam: :custom_timestamp_callback
   invisible_captcha honeypot: :subtitle, only: :publish, timestamp_threshold: 2
+  invisible_captcha honeypot: :subtitle, only: :copy, timestamp_enabled: false
+
+  def index
+    redirect_to new_topic_path
+  end
 
   def new
     @topic = Topic.new
@@ -24,6 +29,16 @@ class TopicsController < ApplicationController
 
   def publish
     redirect_to new_topic_path
+  end
+
+  def copy
+    @topic = Topic.new(params[:topic])
+
+    if @topic.valid?
+      redirect_to new_topic_path(context: params[:context]), notice: 'Success!'
+    else
+      render action: 'new'
+    end
   end
 
   private

--- a/spec/dummy/app/models/topic.rb
+++ b/spec/dummy/app/models/topic.rb
@@ -5,6 +5,7 @@ class Topic
   attr_accessor :title, :author, :body, :subtitle
 
   validates :title, :author, presence: true
+  validates :title, length: { minimum: 10 }
 
   def initialize(attributes = {})
     attributes.each do |name, value|

--- a/spec/dummy/app/models/topic.rb
+++ b/spec/dummy/app/models/topic.rb
@@ -4,8 +4,9 @@ class Topic
 
   attr_accessor :title, :author, :body, :subtitle
 
-  validates :title, :author, presence: true
-  validates :title, length: { minimum: 10 }
+  validates :title, length: { minimum: 5 }
+  validates :author, presence: true
+  validates :body, length: { minimum: 10 }
 
   def initialize(attributes = {})
     attributes.each do |name, value|

--- a/spec/dummy/app/models/topic.rb
+++ b/spec/dummy/app/models/topic.rb
@@ -2,9 +2,9 @@ class Topic
   include ActiveModel::Validations
   include ActiveModel::Conversion
 
-  attr_accessor :title, :body, :subtitle
+  attr_accessor :title, :author, :body, :subtitle
 
-  validates :title, presence: true
+  validates :title, :author, presence: true
 
   def initialize(attributes = {})
     attributes.each do |name, value|

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -8,20 +8,22 @@
   <%= invisible_captcha_styles %>
 </head>
 <body>
+  <h1>InvisibleCaptcha v<%= InvisibleCaptcha::VERSION %> - Demo</h1>
 
-<%= link_to "Default", new_topic_path %> |
-<%= link_to "With visual honeypots", new_topic_path(context: "visual_honeypots") %> |
-<%= link_to "With timestamp disabled", new_topic_path(context: "timestamp_disabled") %>
+  <p>
+    <%= link_to "Default settings", new_topic_path %> |
+    <%= link_to "With visual honeypots", new_topic_path(context: "visual_honeypots") %> |
+    <%= link_to "With timestamp disabled", new_topic_path(context: "timestamp_disabled") %>
+  </p>
 
-<% flash.each do |key, value| %>
-  <ul class="errors">
-    <li>
-      <%= "[#{key.upcase}] #{value}" %>
-    </li>
-  </ul>
-<% end %>
+  <% flash.each do |key, value| %>
+    <ul class="errors">
+      <li>
+        <%= "[#{key.upcase}] #{value}" %>
+      </li>
+    </ul>
+  <% end %>
 
-<%= yield %>
-
-</body>
+  <%= yield %>
+  </body>
 </html>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -9,10 +9,11 @@
 <body>
 
 <%= link_to "Default", new_topic_path %> |
-<%= link_to "With visual honeypots", new_topic_path(context: "visual_honeypots") %>
+<%= link_to "With visual honeypots", new_topic_path(context: "visual_honeypots") %> |
+<%= link_to "With timestamp disabled", new_topic_path(context: "timestamp_disabled") %>
 
 <% flash.each do |key, value| %>
-  <ul>
+  <ul class="errors">
     <li>
       <%= "[#{key.upcase}] #{value}" %>
     </li>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
+  <%= invisible_captcha_styles %>
 </head>
 <body>
 

--- a/spec/dummy/app/views/topics/new.html.erb
+++ b/spec/dummy/app/views/topics/new.html.erb
@@ -1,11 +1,3 @@
-<h1>
-  <% if params[:context] == 'timestamp_disabled' %>
-    Copy topic (action with timestamp disabled)
-  <% else %>
-    New topic
-  <% end %>
-</h1>
-
 <% if @topic.errors.any? %>
   <div class="errors">
     <strong><%= pluralize(@topic.errors.count, "error") %> prohibited this record from being saved:</strong>
@@ -42,6 +34,6 @@
   </div>
 
   <div class="actions">
-    <%= f.submit 'Save' %>
+    <%= f.button 'Save' %>
   </div>
 <% end %>

--- a/spec/dummy/app/views/topics/new.html.erb
+++ b/spec/dummy/app/views/topics/new.html.erb
@@ -1,8 +1,14 @@
-<h1>New topic</h1>
+<h1>
+  <% if params[:context] == 'timestamp_disabled' %>
+    Copy topic (action with timestamp disabled)
+  <% else %>
+    New topic
+  <% end %>
+</h1>
 
 <% if @topic.errors.any? %>
-  <div>
-    <h2><%= pluralize(@topic.errors.count, "error") %> prohibited this record from being saved:</h2>
+  <div class="errors">
+    <strong><%= pluralize(@topic.errors.count, "error") %> prohibited this record from being saved:</strong>
     <ul>
       <% @topic.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
@@ -11,13 +17,13 @@
   </div>
 <% end %>
 
-<%= form_for(@topic) do |f| %>
+<%= form_for(@topic, url: { action: params[:context] == 'timestamp_disabled' ? :copy : :create }) do |f| %>
   <%= hidden_field_tag :context, params[:context] %>
 
-  <% if params[:context].blank? || params[:context] == 'default' %>
-    <%= f.invisible_captcha :subtitle %>
-  <% else %>
+  <% if params[:context] && params[:context] == 'visual_honeypots' %>
     <%= f.invisible_captcha :subtitle, visual_honeypots: true %>
+  <% else %>
+    <%= f.invisible_captcha :subtitle %>
   <% end %>
 
   <div class="field">
@@ -26,11 +32,16 @@
   </div>
 
   <div class="field">
+    <%= f.label :author %><br />
+    <%= f.text_field :author %>
+  </div>
+
+  <div class="field">
     <%= f.label :body %><br />
-    <%= f.text_area :body %>
+    <%= f.text_area :body, rows: 10, cols: 40 %>
   </div>
 
   <div class="actions">
-    <%= f.submit %>
+    <%= f.submit 'Save' %>
   </div>
 <% end %>

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -4,6 +4,7 @@ require 'action_controller/railtie'
 require 'action_view/railtie'
 require 'action_mailer/railtie'
 require 'active_model/railtie'
+require 'sprockets/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -31,6 +31,9 @@ Dummy::Application.configure do
   # yet still be able to expire them through the digest params.
   # config.assets.digest = true
 
+  # quiet assets
+  config.assets.quiet = true
+
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.

--- a/spec/dummy/config/initializers/invisible_captcha.rb
+++ b/spec/dummy/config/initializers/invisible_captcha.rb
@@ -1,6 +1,0 @@
-InvisibleCaptcha.setup do |config|
-  # config.sentence_for_humans = 'If you are a human, ignore this field'
-  # config.error_message       = 'You are a robot!'
-  # config.honeypots          += 'fake_resource_title'
-  # config.visual_honeypots    = false
-end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
-  resources :topics, only: [:new, :create, :update] do
-    member do
-      post :publish
-    end
+  resources :topics do
+    post :publish, on: :member
+    post :copy, on: :collection
   end
 
   root to: 'topics#new'

--- a/spec/invisible_captcha_spec.rb
+++ b/spec/invisible_captcha_spec.rb
@@ -5,10 +5,10 @@ describe InvisibleCaptcha do
     InvisibleCaptcha.init!
 
     expect(InvisibleCaptcha.sentence_for_humans).to eq('If you are a human, ignore this field')
-    expect(InvisibleCaptcha.error_message).to eq('You are a robot!')
     expect(InvisibleCaptcha.timestamp_threshold).to eq(4.seconds)
     expect(InvisibleCaptcha.timestamp_error_message).to eq('Sorry, that was too quick! Please resubmit.')
-    expect(InvisibleCaptcha.honeypots).to eq(['foo_id', 'bar_id', 'baz_id'])
+    expect(InvisibleCaptcha.honeypots).to be_an_instance_of(Array)
+    expect(InvisibleCaptcha.injectable_styles).to eq(false)
   end
 
   it 'allow setup via block' do
@@ -27,28 +27,23 @@ describe InvisibleCaptcha do
     I18n.backend.store_translations(:en,
                                     'invisible_captcha' => {
                                        'sentence_for_humans' => "Can't touch this",
-                                       'error_message' => 'MR ROBOT',
                                        'timestamp_error_message' => 'Fast and furious' })
 
     I18n.backend.store_translations(:fr,
                                     'invisible_captcha' => {
                                        'sentence_for_humans' => 'Ne touchez pas',
-                                       'error_message' => 'Mon dieu, un robot!',
                                        'timestamp_error_message' => 'Plus doucement SVP' })
 
     I18n.locale = :en
     expect(InvisibleCaptcha.sentence_for_humans).to eq("Can't touch this")
-    expect(InvisibleCaptcha.error_message).to eq('MR ROBOT')
     expect(InvisibleCaptcha.timestamp_error_message).to eq('Fast and furious')
 
     I18n.locale = :fr
     expect(InvisibleCaptcha.sentence_for_humans).to eq('Ne touchez pas')
-    expect(InvisibleCaptcha.error_message).to eq('Mon dieu, un robot!')
     expect(InvisibleCaptcha.timestamp_error_message).to eq('Plus doucement SVP')
 
     I18n.backend.reload!
     expect(InvisibleCaptcha.sentence_for_humans).to eq('If you are a human, ignore this field')
-    expect(InvisibleCaptcha.error_message).to eq('You are a robot!')
     expect(InvisibleCaptcha.timestamp_error_message).to eq('Sorry, that was too quick! Please resubmit.')
   end
 end

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 describe InvisibleCaptcha::ViewHelpers, type: :helper do
   before(:each) do
     allow(Time.zone).to receive(:now).and_return(Time.zone.parse('Feb 19 1986'))
-    @view_flow = ActionView::OutputFlow.new # to test content_for and provide
+    allow(InvisibleCaptcha).to receive(:css_strategy).and_return("display:none;")
+
+    # to test content_for and provide
+    @view_flow = ActionView::OutputFlow.new
+
     InvisibleCaptcha.init!
   end
 

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -27,7 +27,7 @@ describe InvisibleCaptcha::ViewHelpers, type: :helper do
   it 'generated html + styles' do
     InvisibleCaptcha.honeypots = [:foo_id]
     output = invisible_captcha.gsub("\"", "'")
-    regexp = %r{<div class='foo_id_\w*'><style .*>.foo_id_\w* {display:none;}</style><label .*>#{InvisibleCaptcha.sentence_for_humans}.*<input .* name='foo_id' .*</div>}
+    regexp = %r{<div class='foo_id_\w*'><style.*>.foo_id_\w* {display:none;}</style><label.*>#{InvisibleCaptcha.sentence_for_humans}.*<input.*name='foo_id'.*tabindex='-1'.*</div>}
 
     expect(output).to match(regexp)
   end

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -51,6 +51,10 @@ describe InvisibleCaptcha::ViewHelpers, type: :helper do
     expect(invisible_captcha(:subtitle, :topic)).to eq(helper_output(:subtitle, :topic))
   end
 
+  it 'with custom html options' do
+    expect(invisible_captcha(:subtitle, :topic, { class: 'foo_class' })).to match(/class="foo_class"/)
+  end
+
   context "honeypot visibilty" do
     it 'visible from defaults' do
       InvisibleCaptcha.honeypots = [:foo_id]

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -1,85 +1,71 @@
 require 'spec_helper'
 
 describe InvisibleCaptcha::ViewHelpers, type: :helper do
-  def helper_output(honeypot = nil, scope = nil, options = {})
-    honeypot ||= InvisibleCaptcha.get_honeypot
-    input_id   = build_label_name(honeypot, scope)
-    input_name = build_text_field_name(honeypot, scope)
-    html_id    = generate_html_id(honeypot, scope)
-    visibilty  = if options.key?(:visual_honeypots)
-      options[:visual_honeypots]
-    else
-      InvisibleCaptcha.visual_honeypots
-    end
-    style_attributes, input_attributes = if Gem::Version.new(Rails.version) > Gem::Version.new("4.2.0")
-      [
-        'type="text/css" media="screen" scoped="scoped"',
-        "type=\"text\" name=\"#{input_name}\" id=\"#{input_id}\""
-      ]
-    else
-      [
-        'media="screen" scoped="scoped" type="text/css"',
-        "id=\"#{input_id}\" name=\"#{input_name}\" type=\"text\""
-      ]
-    end
-
-    %{
-      <div id="#{html_id}">
-        <style #{style_attributes}>#{visibilty ? '' : "##{html_id} { display:none; }"}</style>
-        <label for="#{input_id}">#{InvisibleCaptcha.sentence_for_humans}</label>
-        <input #{input_attributes} />
-      </div>
-    }.gsub(/\s+/, ' ').strip.gsub('> <', '><')
-  end
-
-  before do
+  before(:each) do
     allow(Time.zone).to receive(:now).and_return(Time.zone.parse('Feb 19 1986'))
-    InvisibleCaptcha.visual_honeypots = false
-    InvisibleCaptcha.timestamp_enabled = true
+    @view_flow = ActionView::OutputFlow.new # to test content_for and provide
+    InvisibleCaptcha.init!
   end
 
   it 'with no arguments' do
     InvisibleCaptcha.honeypots = [:foo_id]
-    expect(invisible_captcha).to eq(helper_output)
+    expect(invisible_captcha).to match(/name="foo_id"/)
   end
 
   it 'with specific honeypot' do
-    expect(invisible_captcha(:subtitle)).to eq(helper_output(:subtitle))
+    expect(invisible_captcha(:subtitle)).to match(/name="subtitle"/)
   end
 
   it 'with specific honeypot and scope' do
-    expect(invisible_captcha(:subtitle, :topic)).to eq(helper_output(:subtitle, :topic))
+    expect(invisible_captcha(:subtitle, :topic)).to match(/name="topic\[subtitle\]"/)
   end
 
   it 'with custom html options' do
     expect(invisible_captcha(:subtitle, :topic, { class: 'foo_class' })).to match(/class="foo_class"/)
   end
 
+  it 'generated html + styles' do
+    InvisibleCaptcha.honeypots = [:foo_id]
+    output = invisible_captcha.gsub("\"", "'")
+    regexp = %r{<div class='foo_id_\w*'><style .*>.foo_id_\w* {display:none;}</style><label .*>#{InvisibleCaptcha.sentence_for_humans}.*<input .* name='foo_id' .*</div>}
+
+    expect(output).to match(regexp)
+  end
+
   context "honeypot visibilty" do
     it 'visible from defaults' do
-      InvisibleCaptcha.honeypots = [:foo_id]
       InvisibleCaptcha.visual_honeypots = true
 
-      expect(invisible_captcha).to eq(helper_output)
+      expect(invisible_captcha).not_to match(/display:none/)
     end
 
     it 'visible from given instance (default override)' do
-      InvisibleCaptcha.honeypots = [:foo_id]
-
-      expect(invisible_captcha(visual_honeypots: true)).to eq(helper_output(nil, nil, visual_honeypots: true))
+      expect(invisible_captcha(visual_honeypots: true)).not_to match(/display:none/)
     end
 
     it 'invisible from given instance (default override)' do
-      InvisibleCaptcha.honeypots = [:foo_id]
       InvisibleCaptcha.visual_honeypots = true
 
-      expect(invisible_captcha(visual_honeypots: false)).to eq(helper_output(nil, nil, visual_honeypots: false))
+      expect(invisible_captcha(visual_honeypots: false)).to match(/display:none/)
     end
   end
 
   it 'should set spam timestamp' do
-    InvisibleCaptcha.honeypots = [:foo_id]
     invisible_captcha
     expect(session[:invisible_captcha_timestamp]).to eq(Time.zone.now.iso8601)
+  end
+
+  context 'injectable_styles option' do
+    it 'by default, render styles along with the honeypot' do
+      expect(invisible_captcha).to match(/display:none/)
+      expect(helper.content_for(:invisible_captcha_styles)).to be_blank
+    end
+
+    it 'if injectable_styles is set, do not append styles inline' do
+      InvisibleCaptcha.injectable_styles = true
+
+      expect(invisible_captcha).not_to match(/display:none;/)
+      expect(helper.content_for(:invisible_captcha_styles)).to match(/display:none;/)
+    end
   end
 end


### PR DESCRIPTION
- new timestamp on each request to avoid stale timestamps (closes #24)
- allow to inject styles manually anywhere in the layout (closes #27) 
- allow to change threshold per action
- dynamic css strategy to hide the honeypot
- remove Ruby 1.9 support
- random default honeypots on each restart
- allow to pass html_options to honeypot input (closes #28)
- improvements on demo application and tests
- better strong parameters interaction (closes #30, done in #33)