### PR TITLE
Remove honeypot from params to avoid UnpermittedParameters exceptions…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,18 @@
 language: ruby
-
 cache: bundler
-
 sudo: false
-
 rvm:
   - ruby-head
   - 2.4.2
   - 2.3.5
   - 2.2.8
   - 2.1.10
-
 gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_3.2.gemfile
-
 matrix:
   exclude:
     - rvm: 2.1.10
@@ -28,6 +23,8 @@ matrix:
       gemfile: gemfiles/rails_4.1.gemfile
     - rvm: 2.4.2
       gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_4.1.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_3.2.gemfile
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ class TopicsController < ApplicationController
 end
 ```
 
-Note that isn't mandatory to specify a `honeypot` attribute (nor in the view, nor in the controller). In this case, the engine will take a random field from `InvisibleCaptcha.honeypots`. So, if you're integrating it following this path, in your form:
+Note that is not mandatory to specify a `honeypot` attribute (nor in the view, nor in the controller). In this case, the engine will take a random field from `InvisibleCaptcha.honeypots`. So, if you're integrating it following this path, in your form:
 
 ```erb
 <%= form_tag(new_contact_path) do |f| %>
@@ -118,7 +118,7 @@ The `invisible_captcha` method accepts some options:
 
 * `only`: apply to given controller actions.
 * `except`: exclude to given controller actions.
-* `honeypot`: name of honeypot.
+* `honeypot`: name of custom honeypot.
 * `scope`: name of scope, ie: 'topic[subtitle]' -> 'topic' is the scope.
 * `on_spam`: custom callback to be called on spam detection.
 * `timestamp_threshold`: enable/disable this technique at action level.
@@ -175,7 +175,8 @@ $ bundle exec rspec
 Run the test suite against all supported versions:
 
 ```
-$ bundle exec appraisal rake
+$ bundle exec appraisal install
+$ bundle exec appraisal rspec
 ```
 
 ### Demo

--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'test-unit', '~> 3.0'
-  spec.add_development_dependency 'mime-types', '< 3.0'
   spec.add_development_dependency 'byebug'
 end
 

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -113,5 +113,12 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
 
       expect(response.body).to redirect_to(new_topic_path)
     end
+
+    it 'honeypot is removed from params if you use a custom honeypot' do
+      switchable_post :create, topic: { title: 'foo', subtitle: '' }
+
+      expect(flash[:error]).not_to be_present
+      expect(@controller.params[:topic].key?(:subtitle)).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
… (this happens if action_on_unpermitted_parameters is set to :raise and you are using your own honeypot: f.invisible_captcha :subtitle)

Closes #30 