### PR TITLE
Add aria hidden to parent element

### DIFF
--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -38,7 +38,7 @@ module InvisibleCaptcha
         styles
       end if InvisibleCaptcha.injectable_styles
 
-      content_tag(:div, class: css_class) do
+      content_tag(:div, class: css_class, aria: { hidden: true }) do
         concat styles unless InvisibleCaptcha.injectable_styles
         concat label_tag(build_label_name(honeypot, scope), label)
         concat text_field_tag(build_text_field_name(honeypot, scope), nil, options.merge(tabindex: -1))


### PR DESCRIPTION
Small improvement for accessibility.

Add `aria-hidden="true"` to the parent div to indicate to screenreaders that it's not to be filled in.