### PR TITLE
Use #remote_ip instead of REMOTE_ADDR

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -102,7 +102,7 @@ module InvisibleCaptcha
     end
 
     def warn(message)
-      logger.warn("Potential spam detected for IP #{request.env['REMOTE_ADDR']}. #{message}")
+      logger.warn("Potential spam detected for IP #{request.remote_ip}. #{message}")
     end
   end
 end


### PR DESCRIPTION
When Rails is behind a proxy server, REMOTE_ADDR will be the IP of the
proxy rather than the user's actual IP. The `request.remote_ip` method
properly accounts for this.

See https://github.com/rails/rails/pull/33489 for a similar change in
Rails.