### PR TITLE
Add option to include autocomplete=off attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,18 @@ You can customize:
 * `timestamp_enabled`: option to disable the time threshold check at application level. Could be useful, for example, on some testing scenarios. By default, true.
 * `timestamp_error_message`: flash error message thrown when form submitted quicker than the `timestamp_threshold` value. It uses I18n by default.
 * `injectable_styles`: if enabled, you should call anywhere in your layout the following helper `<%= invisible_captcha_styles %>`. This allows you to inject styles, for example, in `<head>`. False by default, styles are injected inline with the honeypot.
+* `disable_autocomplete`: if enabled, includes the `autocomplete="off"` attribute in the html input tag. This helps to avoid false positives caused by form filling browser extensions. True by default.
 
 To change these defaults, add the following to an initializer (recommended `config/initializers/invisible_captcha.rb`):
 
 ```ruby
 InvisibleCaptcha.setup do |config|
   # config.honeypots           << ['more', 'fake', 'attribute', 'names']
-  # config.visual_honeypots    = false
-  # config.timestamp_threshold = 4
-  # config.timestamp_enabled   = true
-  # config.injectable_styles   = false
+  # config.visual_honeypots     = false
+  # config.timestamp_threshold  = 4
+  # config.timestamp_enabled    = true
+  # config.injectable_styles    = false
+  # config.disable_autocomplete = true
 
   # Leave these unset if you want to use I18n (see below)
   # config.sentence_for_humans     = 'If you are a human, ignore this field'

--- a/lib/invisible_captcha.rb
+++ b/lib/invisible_captcha.rb
@@ -13,7 +13,8 @@ module InvisibleCaptcha
                   :timestamp_threshold,
                   :timestamp_enabled,
                   :visual_honeypots,
-                  :injectable_styles
+                  :injectable_styles,
+                  :disable_autocomplete
 
     def init!
       # Default sentence for real users if text field was visible
@@ -34,6 +35,9 @@ module InvisibleCaptcha
       # If enabled, you should call anywhere in of your layout the following helper, to inject the honeypot styles:
       #  <%= invisible_captcha_styles %>
       self.injectable_styles = false
+
+      # Set the `autocomplete="off"` attribute of input fields
+      self.disable_autocomplete = true
     end
 
     def sentence_for_humans

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -34,6 +34,13 @@ module InvisibleCaptcha
 
       styles = visibility_css(css_class, options)
 
+      baseline_options = {}.tap do |opts|
+        opts[:tabindex] = -1
+        if options.fetch(:disable_autocomplete) { InvisibleCaptcha.disable_autocomplete }
+          opts[:autocomplete] = "off"
+        end
+      end
+
       provide(:invisible_captcha_styles) do
         styles
       end if InvisibleCaptcha.injectable_styles
@@ -41,7 +48,7 @@ module InvisibleCaptcha
       content_tag(:div, class: css_class) do
         concat styles unless InvisibleCaptcha.injectable_styles
         concat label_tag(build_label_name(honeypot, scope), label)
-        concat text_field_tag(build_text_field_name(honeypot, scope), nil, options.merge(tabindex: -1))
+        concat text_field_tag(build_text_field_name(honeypot, scope), nil, options.merge(baseline_options))
       end
     end
 

--- a/spec/invisible_captcha_spec.rb
+++ b/spec/invisible_captcha_spec.rb
@@ -9,6 +9,7 @@ describe InvisibleCaptcha do
     expect(InvisibleCaptcha.timestamp_error_message).to eq('Sorry, that was too quick! Please resubmit.')
     expect(InvisibleCaptcha.honeypots).to be_an_instance_of(Array)
     expect(InvisibleCaptcha.injectable_styles).to eq(false)
+    expect(InvisibleCaptcha.disable_autocomplete).to eq(true)
   end
 
   it 'allow setup via block' do

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -72,4 +72,30 @@ describe InvisibleCaptcha::ViewHelpers, type: :helper do
       expect(@view_flow.content[:invisible_captcha_styles]).to match(/display:none;/)
     end
   end
+
+  context 'disable_autocomplete option' do
+    it 'includes the autocomplete="off" html attribute when true' do
+      InvisibleCaptcha.disable_autocomplete = true
+      expect(invisible_captcha).to match(/input.* autocomplete="off".*>/)
+    end
+
+    it 'does not include the autocomplete="off" html attribute when false' do
+      InvisibleCaptcha.disable_autocomplete = false
+      expect(invisible_captcha).not_to match(/autocomplete="off"/)
+    end
+
+    it 'overrides defaults with passed options' do
+      pattern = /input.* autocomplete="off".*>/
+
+      InvisibleCaptcha.disable_autocomplete = true
+      expect(invisible_captcha(:subtitle, :topic, {})).to match(pattern)
+      expect(invisible_captcha(:subtitle, :topic, { disable_autocomplete: true })).to match(pattern)
+      expect(invisible_captcha(:subtitle, :topic, { disable_autocomplete: false })).not_to match(pattern)
+
+      InvisibleCaptcha.disable_autocomplete = false
+      expect(invisible_captcha(:subtitle, :topic, {})).not_to match(pattern)
+      expect(invisible_captcha(:subtitle, :topic, { disable_autocomplete: true })).to match(pattern)
+      expect(invisible_captcha(:subtitle, :topic, { disable_autocomplete: false })).not_to match(pattern)
+    end
+  end
 end


### PR DESCRIPTION
This change adds a new (default true) option called `disable_autocomplete`. When enabled, the `autocomplete="off"` attribute will be included in the HTML `input` tag.

This resolves issue #42.