### PR TITLE
Clear invisible_captcha_timestamp session entry after use [Issue #49]

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -19,10 +19,11 @@ module InvisibleCaptcha
     def detect_spam(options = {})
       if timestamp_spam?(options)
         on_timestamp_spam(options)
-        clear_session
       elsif honeypot_spam?(options)
         on_spam(options)
       end
+
+      clear_session
     end
 
     def on_timestamp_spam(options = {})

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -19,6 +19,7 @@ module InvisibleCaptcha
     def detect_spam(options = {})
       if timestamp_spam?(options)
         on_timestamp_spam(options)
+        clear_session
       elsif honeypot_spam?(options)
         on_spam(options)
       end
@@ -71,6 +72,10 @@ module InvisibleCaptcha
       end
 
       false
+    end
+
+    def clear_session
+      session.delete(:invisible_captcha_timestamp) if session[:invisible_captcha_timestamp]
     end
 
     def honeypot_spam?(options = {})

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -75,10 +75,17 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
       it 'passes if submission on or after timestamp_threshold' do
         sleep InvisibleCaptcha.timestamp_threshold
 
-        switchable_post :create, topic: { title: 'foo' }
+        switchable_post :create, topic: {
+          title: 'foobar',
+          author: 'author',
+          body: 'body that passes validation'
+        }
 
         expect(flash[:error]).not_to be_present
         expect(response.body).to be_present
+
+        # Make sure session is cleared
+        expect(session[:invisible_captcha_timestamp]).to be_nil
       end
 
       it 'allow to set a custom timestamp_threshold per action' do

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -60,6 +60,9 @@ describe InvisibleCaptcha::ControllerExt, type: :controller do
 
       expect(response).to redirect_to 'http://test.host/topics'
       expect(flash[:error]).to eq(InvisibleCaptcha.timestamp_error_message)
+
+      # Make sure session is cleared
+      expect(session[:invisible_captcha_timestamp]).to be_nil
     end
 
     it 'allow a custom on_timestamp_spam callback' do


### PR DESCRIPTION
As discussed in https://github.com/markets/invisible_captcha/issues/49, this clears out the timestamp from the session after use.