### PR TITLE
Adding support to use 'prepend_before_action' instead of regular 'before_action'

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ class TopicsController < ApplicationController
 end
 ```
 
+If `prepend: true` is given as options to `invisible_captcha` then a `prepend_before_action` (or `prepend_before_filter`) will be used instead.
+
 Note that is not mandatory to specify a `honeypot` attribute (nor in the view, nor in the controller). In this case, the engine will take a random field from `InvisibleCaptcha.honeypots`. So, if you're integrating it following this path, in your form:
 
 ```erb

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -3,12 +3,24 @@ module InvisibleCaptcha
     module ClassMethods
       def invisible_captcha(options = {})
         if respond_to?(:before_action)
-          before_action(options) do
-            detect_spam(options)
+          if options.key?(:prepend)
+            prepend_before_action(options) do
+              detect_spam(options)
+            end
+          else
+            before_action(options) do
+              detect_spam(options)
+            end
           end
         else
-          before_filter(options) do
-            detect_spam(options)
+          if options.key?(:prepend)
+            prepend_before_filter(options) do
+              detect_spam(options)
+            end
+          else
+            before_filter(options) do
+              detect_spam(options)
+            end
           end
         end
       end


### PR DESCRIPTION
This is because on latest version of `devise` I needed `invisible_captcha` to acts a  `prepend_before_action` instead of `before_action`. Otherwise it doesn't work.

/cc @markets 