### PR TITLE
Allow rendering instead of redirecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.2]
+
+- Allow new timestamp to be set during `on_timestamp_spam` callback (#53)
+
+
 ## [0.12.1]
 
 - Clear timestamp stored in `session[:invisible_captcha_timestamp]` (#50)

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -22,8 +22,6 @@ module InvisibleCaptcha
       elsif honeypot_spam?(options)
         on_spam(options)
       end
-
-      clear_session
     end
 
     def on_timestamp_spam(options = {})
@@ -55,15 +53,15 @@ module InvisibleCaptcha
 
       return false unless enabled
 
-      timestamp = session[:invisible_captcha_timestamp]
+      @invisible_captcha_timestamp ||= session.delete(:invisible_captcha_timestamp)
 
       # Consider as spam if timestamp not in session, cause that means the form was not fetched at all
-      unless timestamp
+      unless @invisible_captcha_timestamp
         warn("Invisible Captcha timestamp not found in session.")
         return true
       end
 
-      time_to_submit = Time.zone.now - DateTime.iso8601(timestamp)
+      time_to_submit = Time.zone.now - DateTime.iso8601(@invisible_captcha_timestamp)
       threshold = options[:timestamp_threshold] || InvisibleCaptcha.timestamp_threshold
 
       # Consider as spam if form submitted too quickly
@@ -72,11 +70,7 @@ module InvisibleCaptcha
         return true
       end
 
-      false
-    end
-
-    def clear_session
-      session.delete(:invisible_captcha_timestamp) if session[:invisible_captcha_timestamp]
+      return false
     end
 
     def honeypot_spam?(options = {})

--- a/lib/invisible_captcha/version.rb
+++ b/lib/invisible_captcha/version.rb
@@ -1,3 +1,3 @@
 module InvisibleCaptcha
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -63,10 +63,23 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
       expect(session[:invisible_captcha_timestamp]).to be_nil
     end
 
-    it 'allow a custom on_timestamp_spam callback' do
+    it 'allows a custom on_timestamp_spam callback' do
       switchable_put :update, id: 1, topic: { title: 'bar' }
 
       expect(response.status).to eq(204)
+    end
+
+    it 'allows a new timestamp to be set in the on_timestamp_spam callback' do
+      @controller.singleton_class.class_eval do
+        def custom_timestamp_callback
+          session[:invisible_captcha_timestamp] = 2.seconds.from_now(Time.zone.now).iso8601
+          head(204)
+        end
+      end
+
+      expect { switchable_put :update, id: 1, topic: { title: 'bar' } }
+        .to change { session[:invisible_captcha_timestamp] }
+        .to be_present
     end
 
     context 'successful submissions' do


### PR DESCRIPTION
This commit modifies `ControllerExt` to avoid clearing a timestamp that was set during an `on_timestamp_callback`. For example, this allows us to call `render :new` in the callback instead of always redirecting.

Instead of explicitly clearing the timestamp at the end of `ControllerExt#detect_spam`, we clear it while we're checking for its existence, before we execute the callback. This allows the callback to set a new timestamp, e.g. by re-rendering the form with the `invisible_captcha`.

This PR also has the benefit of removing the `clear_session` method, whose name was probably too generic to mix into a controller, especially when it did not actually clear the entire session.