### PR TITLE
Update rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache: bundler
 sudo: false
 rvm:
   - ruby-head
-  - 2.6.2
-  - 2.5.5
-  - 2.4.5
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9
   - 2.3.8
   - 2.2.10
 gemfile:
@@ -22,7 +22,7 @@ before_install:
   - rvm @global do yes | gem install bundler -v '< 2'
 matrix:
   exclude:
-    - rvm: 2.4.5
+    - rvm: 2.4.9
       gemfile: gemfiles/rails_6.0.gemfile
     - rvm: 2.3.8
       gemfile: gemfiles/rails_6.0.gemfile
@@ -30,11 +30,11 @@ matrix:
       gemfile: gemfiles/rails_6.0.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.6.2
+    - rvm: 2.6.5
       gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.5.5
+    - rvm: 2.5.7
       gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.4.5
+    - rvm: 2.4.9
       gemfile: gemfiles/rails_3.2.gemfile
   allow_failures:
     - rvm: ruby-head

--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -22,4 +22,3 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'test-unit', '~> 3.0'
   spec.add_development_dependency 'byebug'
 end
-

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
This PR updates Rubies to the latest point releases. I've also added missing manifest file for sprockets because tests were failing on my local dev environment (Ruby 2.6.5)

```
An error occurred while loading spec_helper.
Failure/Error: Rails.application.initialize!

Sprockets::Railtie::ManifestNeededError:
  Expected to find a manifest file in `app/assets/config/manifest.js`
  But did not, please create this file and use it to link any assets that need
  to be rendered by your app:

  Example:
    //= link_tree ../images
    //= link_directory ../javascripts .js
    //= link_directory ../stylesheets .css
  and restart your server
# ./spec/dummy/config/environment.rb:5:in `<top (required)>'
# ./spec/spec_helper.rb:3:in `require'
# ./spec/spec_helper.rb:3:in `<top (required)>'
No examples found.
No examples found.


Finished in 0.00004 seconds (files took 0.94715 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Finished in 0.00004 seconds (files took 0.94715 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples 
```