### PR TITLE
Add Instrumentation event

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -105,6 +105,12 @@ module InvisibleCaptcha
 
     def warn(message)
       logger.warn("Potential spam detected for IP #{request.remote_ip}. #{message}")
+
+      ActiveSupport::Notifications.instrument(
+        'invisible_captcha.spam_detected',
+        message: message,
+        request: request
+      )
     end
   end
 end

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -113,7 +113,8 @@ module InvisibleCaptcha
         user_agent: request.user_agent,
         controller: params[:controller],
         action: params[:action],
-        url: request.url
+        url: request.url,
+        params: params
       )
     end
   end

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -109,7 +109,11 @@ module InvisibleCaptcha
       ActiveSupport::Notifications.instrument(
         'invisible_captcha.spam_detected',
         message: message,
-        request: request
+        remote_ip: request.remote_ip,
+        user_agent: request.user_agent,
+        controller: params[:controller],
+        action: params[:action],
+        url: request.url
       )
     end
   end

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -114,7 +114,7 @@ module InvisibleCaptcha
         controller: params[:controller],
         action: params[:action],
         url: request.url,
-        params: params
+        params: request.filtered_parameters
       )
     end
   end

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
 
       let!(:subscriber) do
         subscriber = ActiveSupport::Notifications.subscribe('invisible_captcha.spam_detected') do |*args, data|
-          dummy_handler.handle_event(data)
+          dummy_handler.handle_event(data.with_indifferent_access)
         end
 
         subscriber

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
       after  { ActiveSupport::Notifications.unsubscribe(subscriber) }
 
       it 'dispatches an `invisible_captcha.spam_detected` event' do
-        expect(dummy_handler).to receive(:handle_event).once.with(
+        expect(dummy_handler).to receive(:handle_event).once.with({
           message: "Invisible Captcha honeypot param 'subtitle' was present.",
           remote_ip: '0.0.0.0',
           user_agent: 'Rails Testing',
@@ -170,7 +170,7 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
             controller: 'topics',
             action: 'create'
           }
-        )
+        }.with_indifferent_access)
 
         switchable_post :create, topic: { subtitle: 'foo' }
       end


### PR DESCRIPTION
I'd like a bit more control over how we log spam detection, so I added a [custom event](https://guides.rubyonrails.org/active_support_instrumentation.html#creating-custom-events) using `ActiveSupport::Notifications`.

The `'invisible_captcha.spam_detected'` event fires when spam is detected, allowing the user (i.e. developers) to handle custom logging to a database, Rollbar, etc:

```ruby
ActiveSupport::Notifications.subscribe 'invisible_captcha.spam_detected' do |name, started, finished, unique_id, data|
  #
  # `data` is a hash with the following attributes:
  #
  # {
  #   message: "Invisible Captcha honeypot param 'zclwijk-uxpyqtf' was present.",
  #   remote_ip: "127.0.0.1",
  #   user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36",
  #   controller: "users",
  #   action:"create",
  #   url:"https://app.lvh.me:5001/users",
  #   params: <ActionController::Parameters {...} >
  # }

  # Log all this context to Rollbar:
  Rollbar.warn(data[:message], data)

  # Record the blocked request in your database:
  SpamRequest.create(data.except(:params))
end
```

~I included `params` because it will be helpful in identifying false positives: I can look at the rest of the submitted form data to see if it was a legitimate request or indeed spam. There are some implications to this — developers will need to ensure they are not accidentally logging sensitive parameters. But this seems like a reasonable tradeoff, given this is "advanced usage" anyway.~

☝️The event is now passed filtered (safe) params https://github.com/markets/invisible_captcha/pull/62/commits/e43fa7d97764d032d4f17a5fe6fc4acb473f4a19

If you generally like the idea, I'll add tests and a guard condition for older versions of Rails that don't have `ActiveSupport::Notifications`.

Let me know what you think!

- [x] Add tests
- [x] Update README
- [x] ~Add guard clause for older versions of Rails~