### PR TITLE
Prepend option for invisible captcha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 spec/dummy/log/*.log
 spec/dummy/tmp/
 .byebug_history
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The `invisible_captcha` method accepts some options:
 - `timestamp_enabled`: enable/disable this technique at action level.
 - `on_timestamp_spam`: custom callback to be called when form submitted too quickly. The default action redirects to `:back` printing a warning in `flash[:error]`.
 - `timestamp_threshold`: custom threshold per controller/action. Overrides the global value for `InvisibleCaptcha.timestamp_threshold`.
-
+- `prepend`: detact spam will use `prepend_before_action` if `prepend: true` otherwise `before_action`.
 ### View helpers options:
 
 Using the view/form helper you can override some defaults for the given instance. Actually, it allows to change:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The `invisible_captcha` method accepts some options:
 - `on_timestamp_spam`: custom callback to be called when form submitted too quickly. The default action redirects to `:back` printing a warning in `flash[:error]`.
 - `timestamp_threshold`: custom threshold per controller/action. Overrides the global value for `InvisibleCaptcha.timestamp_threshold`.
 - `prepend`: detact spam will use `prepend_before_action` if `prepend: true` otherwise `before_action`.
+
 ### View helpers options:
 
 Using the view/form helper you can override some defaults for the given instance. Actually, it allows to change:

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -4,8 +4,14 @@ module InvisibleCaptcha
   module ControllerExt
     module ClassMethods
       def invisible_captcha(options = {})
-        before_action(options) do
-          detect_spam(options)
+        if options.key?(:prepend)
+          prepend_before_action(options) do
+            detect_spam(options)
+          end
+        else
+          before_action(options) do
+            detect_spam(options)
+          end
         end
       end
     end

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -40,7 +40,7 @@ module InvisibleCaptcha
         styles
       end if InvisibleCaptcha.injectable_styles
 
-      content_tag(:div, class: css_class) do
+      content_tag(:div, class: css_class, aria: { hidden: true }) do
         concat styles unless InvisibleCaptcha.injectable_styles
         concat label_tag(build_label_name(honeypot, scope), label)
         concat text_field_tag(build_input_name(honeypot, scope), nil, default_honeypot_options.merge(options))

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -40,7 +40,7 @@ module InvisibleCaptcha
         styles
       end if InvisibleCaptcha.injectable_styles
 
-      content_tag(:div, class: css_class, aria: { hidden: true }) do
+      content_tag(:div, class: css_class) do
         concat styles unless InvisibleCaptcha.injectable_styles
         concat label_tag(build_label_name(honeypot, scope), label)
         concat text_field_tag(build_input_name(honeypot, scope), nil, default_honeypot_options.merge(options))


### PR DESCRIPTION
- Gives users an option if they want to use invisible_captcha before_action or prepend_before_action
- Minor accessibility issue fixed
- Added .DS_Store in the .gitignore