### PR TITLE
Specify a default value for form helper argument

### DIFF
--- a/lib/invisible_captcha/form_helpers.rb
+++ b/lib/invisible_captcha/form_helpers.rb
@@ -2,7 +2,7 @@
 
 module InvisibleCaptcha
   module FormHelpers
-    def invisible_captcha(honeypot, options = {})
+    def invisible_captcha(honeypot = nil, options = {})
       @template.invisible_captcha(honeypot, self.object_name, options)
     end
   end

--- a/spec/form_helpers_spec.rb
+++ b/spec/form_helpers_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe InvisibleCaptcha::FormHelpers, type: :helper do
+  let(:object_name) { 'object_name' }
+
+  before(:each) do
+    @template = double
+
+    InvisibleCaptcha.init!
+  end
+
+  it 'with no arguments' do
+    InvisibleCaptcha.honeypots = [:foo_id]
+
+    expect(@template).to receive(:invisible_captcha).with(nil, object_name, {})
+
+    invisible_captcha
+  end
+end


### PR DESCRIPTION
This allows the form helper to be called without arguments, as with the view helper.