### PR TITLE
Add tag_name option

### DIFF
--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -45,6 +45,7 @@ module InvisibleCaptcha
       honeypot  = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
       label     = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
       css_class = "#{honeypot}_#{Time.zone.now.to_i}"
+      content_tag_name = options.delete(:tag_name) || :div
 
       styles = visibility_css(css_class, options)
 
@@ -52,7 +53,7 @@ module InvisibleCaptcha
         styles
       end if InvisibleCaptcha.injectable_styles
 
-      content_tag(:div, class: css_class) do
+      content_tag(content_tag_name, class: css_class) do
         concat styles unless InvisibleCaptcha.injectable_styles
         concat label_tag(build_label_name(honeypot, scope), label)
         concat text_field_tag(build_input_name(honeypot, scope), nil, default_honeypot_options.merge(options))

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe InvisibleCaptcha::ViewHelpers, type: :helper do
     expect(invisible_captcha(:subtitle, :topic, { nonce: true })).to match(/nonce="123"/)
   end
 
+  it 'with tag_name option' do
+    expect(invisible_captcha(:subtitle, :topic, { tag_name: :fieldset })).to start_with('<fieldset ')
+  end
+
   it 'generated html + styles' do
     InvisibleCaptcha.honeypots = [:foo_id]
     output = invisible_captcha.gsub("\"", "'")


### PR DESCRIPTION
Adds a `tag_name` option for customising the outer content tag.