### PR TITLE
Depend on railties gem instead of rails gem

### DIFF
--- a/invisible_captcha.gemspec
+++ b/invisible_captcha.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rails', '>= 5.0'
+  spec.add_dependency 'railties', '>= 5.0'
 
+  spec.add_development_dependency 'activemodel', '>= 5.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'appraisal'
 end


### PR DESCRIPTION
This allows for the gem to be used in apps that depend on the railties gem instead of the rails gem.

Adding activemodel as a development dependency, as that's used by the specs.