### PR TITLE
Allow random honeypots to be scoped

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -98,10 +98,7 @@ module InvisibleCaptcha
         end
       else
         InvisibleCaptcha.honeypots.each do |default_honeypot|
-          if params[default_honeypot].present?
-            warn_spam("Invisible Captcha honeypot param '#{default_honeypot}' was present.")
-            return true
-          elsif params.dig(scope, default_honeypot).present?
+          if params[default_honeypot].present? || params.dig(scope, default_honeypot).present?
             warn_spam("Invisible Captcha honeypot param '#{scope}.#{default_honeypot}' was present.")
             return true
           end

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -101,6 +101,9 @@ module InvisibleCaptcha
           if params[default_honeypot].present?
             warn_spam("Invisible Captcha honeypot param '#{default_honeypot}' was present.")
             return true
+          elsif params.dig(scope, default_honeypot).present?
+            warn_spam("Invisible Captcha honeypot param '#{scope}.#{default_honeypot}' was present.")
+            return true
           end
         end
       end

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -138,11 +138,9 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
 
       context 'with no scope' do
         it 'passes with no spam' do
-          $DOPRY = true
           post :categorize
 
           expect(response.body).to be_present
-          $DOPRY = false
         end
 
         it 'fails with spam' do

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -121,6 +121,52 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
       expect(response.body).to be_present
     end
 
+    context 'with random honeypot' do
+      context 'auto-scoped' do
+        it 'passes with no spam' do
+          post :categorize, params: { topic: { title: 'foo' } }
+
+          expect(response.body).to be_present
+        end
+
+        it 'fails with spam' do
+          post :categorize, params: { topic: { "#{InvisibleCaptcha.honeypots.sample}": 'foo' } }
+
+          expect(response.body).to be_blank
+        end
+      end
+
+      context 'with no scope' do
+        it 'passes with no spam' do
+          $DOPRY = true
+          post :categorize
+
+          expect(response.body).to be_present
+          $DOPRY = false
+        end
+
+        it 'fails with spam' do
+          post :categorize, params: { "#{InvisibleCaptcha.honeypots.sample}": 'foo' }
+
+          expect(response.body).to be_blank
+        end
+      end
+
+      context 'with scope' do
+        it 'fails with spam' do
+          post :rename, params: { topic: { "#{InvisibleCaptcha.honeypots.sample}": 'foo' } }
+
+          expect(response.body).to be_blank
+        end
+
+        it 'passes with no spam' do
+          post :rename, params: { topic: { title: 'foo' } }
+
+          expect(response.body).to be_blank
+        end
+      end
+    end
+
     it 'allow a custom on_spam callback' do
       put :update,  params: { id: 1, topic: { subtitle: 'foo' } }
 

--- a/spec/dummy/app/controllers/topics_controller.rb
+++ b/spec/dummy/app/controllers/topics_controller.rb
@@ -9,6 +9,10 @@ class TopicsController < ApplicationController
 
   invisible_captcha honeypot: :subtitle, only: :copy, timestamp_enabled: false
 
+  invisible_captcha scope: :topic, only: :rename
+
+  invisible_captcha only: :categorize
+
   def index
     redirect_to new_topic_path
   end
@@ -28,6 +32,14 @@ class TopicsController < ApplicationController
   end
 
   def update
+    redirect_to new_topic_path
+  end
+
+  def rename
+  end
+
+  def categorize
+    redirect_to new_topic_path
   end
 
   def publish

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   resources :topics do
     post :publish, on: :member
+
+    post :rename, on: :collection
+    post :categorize, on: :collection
     post :copy, on: :collection
   end
 


### PR DESCRIPTION
Adds logic to allow using `:scope` option without also setting the `:honeypot` option, in the Controller Helper `invisible_captcha`.

Rephrased: Allow randomly generated honeypots that are also explicitly scoped.

Also added + updated tests around randomly generated honeypots.

Should achieve the functionality requested in #71, which I also bumped into in my own project, and was the catalyst for this PR.