### PR TITLE
Protect against parameter with the same name as controller

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -88,7 +88,7 @@ module InvisibleCaptcha
         # If honeypot is defined for this controller-action, search for:
         # - honeypot: params[:subtitle]
         # - honeypot with scope: params[:topic][:subtitle]
-        if params[honeypot].present? || params.dig(scope, honeypot).present?
+        if params[honeypot].present? || (params[scope].respond_to?(:dig) && params.dig(scope, honeypot).present?)
           warn_spam("Honeypot param '#{honeypot}' was present.")
           return true
         else
@@ -98,7 +98,7 @@ module InvisibleCaptcha
         end
       else
         InvisibleCaptcha.honeypots.each do |default_honeypot|
-          if params[default_honeypot].present? || params.dig(scope, default_honeypot).present?
+          if params[default_honeypot].present? || (params[scope].respond_to?(:dig) && params.dig(scope, default_honeypot).present?)
             warn_spam("Honeypot param '#{scope}.#{default_honeypot}' was present.")
             return true
           end

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
 
           expect(response.body).to be_blank
         end
+
+        context 'with parameter the same name as the controller' do
+          it 'passes with no spam' do
+            post :categorize, params: { topic: 'something' }
+
+            expect(response.body).to be_present
+          end
+        end
       end
 
       context 'with no scope' do
@@ -147,6 +155,14 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
           post :categorize, params: { "#{InvisibleCaptcha.honeypots.sample}": 'foo' }
 
           expect(response.body).to be_blank
+        end
+
+        context 'with parameter the same name as the controller' do
+          it 'passes with no spam' do
+            post :categorize, params: { topic: 'something' }
+
+            expect(response.body).to be_present
+          end
         end
       end
 


### PR DESCRIPTION
Closes #122 

When defaulting the scope, we're using the singularized controller name. This leads to a `TypeError` when digging through the parameters if someone supplies a value for that parameter, i.e., a String instead of model-scoped parameters.

This (admittedly kludgy) approach checks to ensure the scope is diggable before proceeding. I don't love the fix here, but it's what I could come up with without making too many changes. Let me know if you'd like to see a different approach.