### PR TITLE
Fix flash message.

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -30,7 +30,8 @@ module InvisibleCaptcha
       if action = options[:on_timestamp_spam]
         send(action)
       else
-        redirect_back(fallback_location: root_path, flash: { error: InvisibleCaptcha.timestamp_error_message })
+        flash[:error] = InvisibleCaptcha.timestamp_error_message
+        redirect_back(fallback_location: root_path)
       end
     end
 


### PR DESCRIPTION
Before:
```ruby
> flash.inspect
=> #<ActionDispatch::Flash::FlashHash:0x0000000116592308 @discard=
#<Set: {"allow_other_host", "flash"}>, @flashes={"allow_other_host"=>false,
"flash"=>{"error"=>"Sorry, that was too quick! Please resubmit."}},
@now=nil> 
```

`flash[:error]` is empty and the error message only accessible as `flash.to_h.dig("flash", "error")`.


Whereas when I manually set `flash[:error]` in Rails, the flash looks like this:
```ruby
#<ActionDispatch::Flash::FlashHash:0x0000000113511418 @discard=
#<Set: {"error"}>, @flashes={"error"=>"AAAA"}, @now=nil>
```