### PR TITLE
Dig can cause weird exceptions

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -89,7 +89,7 @@ module InvisibleCaptcha
         # If honeypot is defined for this controller-action, search for:
         # - honeypot: params[:subtitle]
         # - honeypot with scope: params[:topic][:subtitle]
-        if params[honeypot].present? || params.dig(scope, honeypot).present?
+        if params[honeypot].present? || (params[scope] && params[scope][honeypot].present?)
           warn_spam("Honeypot param '#{honeypot}' was present.")
           return true
         else
@@ -99,7 +99,7 @@ module InvisibleCaptcha
         end
       else
         InvisibleCaptcha.honeypots.each do |default_honeypot|
-          if params[default_honeypot].present? || params.dig(scope, default_honeypot).present?
+          if params[default_honeypot].present? || (params[scope] && params[scope][default_honeypot].present?)
             warn_spam("Honeypot param '#{scope}.#{default_honeypot}' was present.")
             return true
           end


### PR DESCRIPTION
# The problem
+ I have a form that doesn't use a model and whose single relevant value has the same name as the controller. The controller is called `OneTimePasswordsController` and the form input field is called `one_time_password`.
+ the code of the `invisible_captcha` gem breaks in unexpected ways
+ I think this PR removes the surprising behaviour

# Where does it happen
+ lines `92` and `102` here call Ruby's `dig` method (permalink for current master's code):
  https://github.com/markets/invisible_captcha/blob/1b70b6ee9351681800e10627411ef9e71be0220f/lib/invisible_captcha/controller_ext.rb#L92-L102
+ JFYI one `dig` was added in this commit:
  https://github.com/markets/invisible_captcha/commit/954312b190fbe71cbd2f738cdb3dd16fa725fa87#diff-0e2f2afd505e226663c121b957ac3ea24ff5cc092ad4fa6a4129351c03407441R91


# Why it happens
+ `dig` throws a `TypeError` exception when `params[scope]` is set (e.g. to a string).

+ simpler Ruby example
  this works:
  ```ruby
  params = { actor: { name: "Nicolas Cage" } }

  # digging with keys that don't exist
  params.dig(:foo, :bar)
  => nil
  ```

  but this breaks with an exception:
  ```ruby
  # digging with keys that partially exist
  params.dig(:actor, :name, :whatever)
  => TypeError: String does not have #dig method
  ```

+ Full article on `dig` and its problems: http://anamaria.martinezgomez.name/2018/01/07/ruby-dig.html
+ related discussion from the Ruby mailing list: https://bugs.ruby-lang.org/issues/11762

## Suggested Fix
+ don't use `dig`, it's not a 1:1 replacement for `params[scope] && params[scope][honeypot]`