### PR TITLE
feat: add notifications extra data option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The `invisible_captcha` method accepts some options:
 - `on_timestamp_spam`: custom callback to be called when form submitted too quickly. The default action redirects to `:back` printing a warning in `flash[:error]`.
 - `timestamp_threshold`: custom threshold per controller/action. Overrides the global value for `InvisibleCaptcha.timestamp_threshold`.
 - `prepend`: the spam detection will run in a `prepend_before_action` if `prepend: true`, otherwise will run in a `before_action`.
+- `notification_extra_data`: extra data to be passed to the spam detection notification. It can be a hash or a proc that returns a hash.
 
 ### View helpers options:
 
@@ -226,6 +227,8 @@ The `data` passed to the subscriber is hash containing information about the req
 ```
 
 **NOTE:** `params` will be filtered according to your `Rails.application.config.filter_parameters` configuration, making them (probably) safe for logging. But always double-check that you're not inadvertently logging sensitive form data, like passwords and credit cards.
+
+**NOTE:** If you're using the `notification_extra_data` option in the `invisible_captcha` controller method, the data will be merged into the `data` hash passed to the subscriber.
 
 ### Content Security Policy
 

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
+  include ApplicationHelper
   protect_from_forgery
 end

--- a/spec/dummy/app/controllers/topics_controller.rb
+++ b/spec/dummy/app/controllers/topics_controller.rb
@@ -1,4 +1,7 @@
 class TopicsController < ApplicationController
+  invisible_captcha only: :archive,
+                    notification_extra_data: -> { { account: current_account } }
+
   invisible_captcha honeypot: :subtitle, only: :create
 
   invisible_captcha honeypot: :subtitle, only: :update,
@@ -62,6 +65,9 @@ class TopicsController < ApplicationController
 
   def test_passthrough
     redirect_to new_topic_path
+  end
+
+  def archive
   end
 
   private

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def current_account
+    "fake_account"
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     post :categorize, on: :collection
     post :copy, on: :collection
     post :test_passthrough, on: :collection
+    post :archive, on: :collection
   end
 
   root to: 'topics#new'


### PR DESCRIPTION
Hey :wave: 

First of all, I want to thank you for this gem.
I've been using it for a while and it's been great.

## Motivation

Recently, I added this gem to a project that is multi tenant and I
wanted to add some extra data to the notifications from the controller.
Specifically, I wanted to add the current account to the notifications
so I could add the tag to the Sentry message captured.

## Proposed changes

I've added a new option to the `invisible_captcha` method that allows
to pass extra data in the following way:

```ruby
invisible_captcha only: :create, extra_data: -> { { account: current_account } }
```

Or if you want to pass a static value:

```ruby
invisible_captcha only: :create, extra_data: { foo: 'bar' }
```

This extra data is merged to the `ActiveSupport::Notifications` payload.
Then, the data available in the `invisible_captcha.solved` event is:

```ruby
{
  message: "[Invisible Captcha] Potential spam detected for IP 0.0.0.0. Timestamp threshold not reached (took 0s).",
  remote_ip: '0.0.0.0',
  user_agent: 'Rails Testing',
  controller: 'topics',
  action: 'archive',
  url: 'http://test.host/topics/archive',
  params: {
    controller: 'topics',
    action: 'archive'
  },
  extra: { account: 'fake_account' }
}
```

---

I hope I am not just scratching my own itch and this feature can be useful for others. :smile: 