### PR TITLE
Add configurable redirect_fallback_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ To change these defaults, add the following to an initializer (recommended `conf
 
 ```ruby
 InvisibleCaptcha.setup do |config|
-  # config.honeypots           << ['more', 'fake', 'attribute', 'names']
-  # config.visual_honeypots    = false
-  # config.timestamp_threshold = 2
-  # config.timestamp_enabled   = true
-  # config.injectable_styles   = false
-  # config.spinner_enabled     = true
+  # config.honeypots              << ['more', 'fake', 'attribute', 'names']
+  # config.visual_honeypots       = false
+  # config.timestamp_threshold    = 2
+  # config.timestamp_enabled      = true
+  # config.injectable_styles      = false
+  # config.spinner_enabled        = true
+  # config.redirect_fallback_path = root_path
 
   # Leave these unset if you want to use I18n (see below)
   # config.sentence_for_humans     = 'If you are a human, ignore this field'

--- a/lib/invisible_captcha.rb
+++ b/lib/invisible_captcha.rb
@@ -18,6 +18,7 @@ module InvisibleCaptcha
                   :injectable_styles,
                   :spinner_enabled,
                   :secret
+                  :redirect_fallback_path
 
     def init!
       # Default sentence for real users if text field was visible

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -34,7 +34,8 @@ module InvisibleCaptcha
         send(action)
       else
         flash[:error] = InvisibleCaptcha.timestamp_error_message
-        redirect_back(fallback_location: root_path)
+        fallback_path = InvisibleCaptcha.redirect_fallback_path || root_path
+        redirect_back(fallback_location: fallback_path)
       end
     end
 


### PR DESCRIPTION
This PR introduces a new configurable option `redirect_fallback_path`. The default behavior currently uses `root_path` as the fallback location in the `redirect_back` method, which might not align with all applications requirements.

With this change, developers can customize the fallback path via the initializer. If no custom path is set, the gem will default to `root_path`, maintaining backward compatibility.

https://github.com/markets/invisible_captcha/issues/140