### PR TITLE
Redirect to '/' if root_path can't be evaluated

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -34,7 +34,7 @@ module InvisibleCaptcha
         send(action)
       else
         flash[:error] = InvisibleCaptcha.timestamp_error_message
-        redirect_back(fallback_location: root_path)
+        redirect_back(fallback_location: defined?(root_path) ? root_path : "/")
       end
     end
 


### PR DESCRIPTION
Fixes #140 

Apps that don't implement a `root_path` fall back to using `/` as the fallback location.