### PR TITLE
Having a @request variable defined in user's controller could be problematic

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,5 +7,9 @@
 ).each do |version|
   appraise "rails-#{version}" do
     gem "rails", "~> #{version}.0"
+
+    # NOTE: concurrent-ruby gem no longer loads the logger gem since v1.3.5.
+    # More info: https://github.com/rails/rails/pull/54264
+    gem "concurrent-ruby", "< 1.3.5"
   end
 end

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -18,7 +18,7 @@ module InvisibleCaptcha
       end
 
       if InvisibleCaptcha.spinner_enabled && @captcha_ocurrences == 1
-        session[:invisible_captcha_spinner] = InvisibleCaptcha.encode("#{session[:invisible_captcha_timestamp]}-#{current_request.remote_ip}")
+        session[:invisible_captcha_spinner] = InvisibleCaptcha.encode("#{session[:invisible_captcha_timestamp]}-#{request.remote_ip}")
       end
 
       build_invisible_captcha(honeypot, scope, options)
@@ -31,10 +31,6 @@ module InvisibleCaptcha
     end
 
     private
-
-    def current_request
-      @request ||= request
-    end
 
     def build_invisible_captcha(honeypot = nil, scope = nil, options = {})
       if honeypot.is_a?(Hash)

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe InvisibleCaptcha::ViewHelpers, type: :helper do
     # to test content_for and provide
     @view_flow = ActionView::OutputFlow.new
 
+    # mock request object for Rails < 7.0
+    if Rails.version < '7.0'
+      allow(request).to receive(:remote_ip).and_return('0.0.0.0')
+    end
+
     InvisibleCaptcha.init!
   end
 


### PR DESCRIPTION
Closes #105

More details 👉🏼 https://github.com/markets/invisible_captcha/issues/105#issuecomment-2608409750. It seems we probably don't need to memoize this variable ... so instead of renaming it to something like `@_current_request` (which will also fix the issue), I think we can just ✂️ 