### PR TITLE
Add honeypot_enabled config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- New `honeypot_enabled` config option (default true). When set to false, the view helper renders no honeypot text input and the controller skips the honeypot param check, while leaving timestamp + spinner protection intact. Useful when password-manager autofill of the honeypot is producing false positives that outweigh the bot-blocking benefit.
+
 ## [2.3.0]
 
 - Run honeypot + spinner checks and their callback also if timestamp triggers but passes through (#132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- New `honeypot_enabled` config option (default true). When set to false, the view helper renders no honeypot text input and the controller skips the honeypot param check, while leaving timestamp + spinner protection intact. Useful when password-manager autofill of the honeypot is producing false positives that outweigh the bot-blocking benefit.
+- New `honeypot_enabled` config option (default true).
 
 ## [2.3.0]
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ You can customize:
 - `timestamp_error_message`: flash error message thrown when form submitted quicker than the `timestamp_threshold` value. It uses I18n by default.
 - `injectable_styles`: if enabled, you should call anywhere in your layout the following helper `<%= invisible_captcha_styles %>`. This allows you to inject styles, for example, in `<head>`. False by default, styles are injected inline with the honeypot.
 - `spinner_enabled`: option to disable the IP spinner validation. By default, true.
+- `honeypot_enabled`: option to disable the honeypot field at the application level. When false, the view helper renders no hidden text input (only the spinner, if `spinner_enabled`) and the controller skips the honeypot param check. Useful if a password manager is autofilling the honeypot for some of your users — false positives outweigh the protection in some setups. By default, true.
 - `secret`: customize the secret key to encode some internal values. By default, it reads the environment variable `ENV['INVISIBLE_CAPTCHA_SECRET']` and fallbacks to random value. Be careful, if you are running multiple Rails instances behind a load balancer, use always the same value via the environment variable.
 
 To change these defaults, add the following to an initializer (recommended `config/initializers/invisible_captcha.rb`):
@@ -130,6 +131,7 @@ InvisibleCaptcha.setup do |config|
   # config.timestamp_enabled   = true
   # config.injectable_styles   = false
   # config.spinner_enabled     = true
+  # config.honeypot_enabled    = true
 
   # Leave these unset if you want to use I18n (see below)
   # config.sentence_for_humans     = 'If you are a human, ignore this field'

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can customize:
 - `timestamp_error_message`: flash error message thrown when form submitted quicker than the `timestamp_threshold` value. It uses I18n by default.
 - `injectable_styles`: if enabled, you should call anywhere in your layout the following helper `<%= invisible_captcha_styles %>`. This allows you to inject styles, for example, in `<head>`. False by default, styles are injected inline with the honeypot.
 - `spinner_enabled`: option to disable the IP spinner validation. By default, true.
-- `honeypot_enabled`: option to disable the honeypot field at the application level. When false, the view helper renders no hidden text input (only the spinner, if `spinner_enabled`) and the controller skips the honeypot param check. Useful if a password manager is autofilling the honeypot for some of your users — false positives outweigh the protection in some setups. By default, true.
+- `honeypot_enabled`: option to disable the honeypot field at the application level. By default, true.
 - `secret`: customize the secret key to encode some internal values. By default, it reads the environment variable `ENV['INVISIBLE_CAPTCHA_SECRET']` and fallbacks to random value. Be careful, if you are running multiple Rails instances behind a load balancer, use always the same value via the environment variable.
 
 To change these defaults, add the following to an initializer (recommended `config/initializers/invisible_captcha.rb`):

--- a/lib/invisible_captcha.rb
+++ b/lib/invisible_captcha.rb
@@ -17,6 +17,7 @@ module InvisibleCaptcha
                   :visual_honeypots,
                   :injectable_styles,
                   :spinner_enabled,
+                  :honeypot_enabled,
                   :secret
 
     def init!
@@ -41,6 +42,11 @@ module InvisibleCaptcha
 
       # Spinner check enabled by default
       self.spinner_enabled = true
+
+      # Honeypot check enabled by default. When false, the view helper renders
+      # only the spinner field (no hidden text input for password managers to
+      # autofill) and the controller skips the honeypot param check.
+      self.honeypot_enabled = true
 
       # A secret key to encode some internal values
       self.secret = ENV['INVISIBLE_CAPTCHA_SECRET'] || SecureRandom.hex(64)

--- a/lib/invisible_captcha.rb
+++ b/lib/invisible_captcha.rb
@@ -43,9 +43,7 @@ module InvisibleCaptcha
       # Spinner check enabled by default
       self.spinner_enabled = true
 
-      # Honeypot check enabled by default. When false, the view helper renders
-      # only the spinner field (no hidden text input for password managers to
-      # autofill) and the controller skips the honeypot param check.
+      # Honeypot check enabled by default
       self.honeypot_enabled = true
 
       # A secret key to encode some internal values

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -24,7 +24,7 @@ module InvisibleCaptcha
         return if performed?
       end
 
-      if honeypot_spam?(options) || spinner_spam?
+      if (InvisibleCaptcha.honeypot_enabled && honeypot_spam?(options)) || spinner_spam?
         on_spam(options)
       end
     end

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -24,7 +24,7 @@ module InvisibleCaptcha
         return if performed?
       end
 
-      if (InvisibleCaptcha.honeypot_enabled && honeypot_spam?(options)) || spinner_spam?
+      if honeypot_spam?(options) || spinner_spam?
         on_spam(options)
       end
     end
@@ -85,6 +85,8 @@ module InvisibleCaptcha
     end
 
     def honeypot_spam?(options = {})
+      return false unless InvisibleCaptcha.honeypot_enabled
+
       honeypot = options[:honeypot]
       scope    = options[:scope] || controller_name.singularize
 

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -33,8 +33,8 @@ module InvisibleCaptcha
     private
 
     def build_invisible_captcha(honeypot = nil, scope = nil, options = {})
-      return '' unless InvisibleCaptcha.honeypot_enabled || InvisibleCaptcha.spinner_enabled
-      
+      return ''.html_safe unless InvisibleCaptcha.honeypot_enabled || InvisibleCaptcha.spinner_enabled
+
       if InvisibleCaptcha.honeypot_enabled
         if honeypot.is_a?(Hash)
           options = honeypot

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -38,11 +38,11 @@ module InvisibleCaptcha
         honeypot = nil
       end
 
-      return build_spinner_only unless InvisibleCaptcha.honeypot_enabled
-
-      honeypot  = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
-      label     = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
-      css_class = "#{honeypot}_#{Time.zone.now.to_i}"
+      if InvisibleCaptcha.honeypot_enabled
+        honeypot  = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
+        label     = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
+        css_class = "#{honeypot}_#{Time.zone.now.to_i}"
+      end
 
       styles = visibility_css(css_class, options)
 
@@ -52,18 +52,14 @@ module InvisibleCaptcha
 
       content_tag(:div, class: css_class) do
         concat styles unless InvisibleCaptcha.injectable_styles
-        concat label_tag(build_label_name(honeypot, scope), label)
-        concat text_field_tag(build_input_name(honeypot, scope), nil, default_honeypot_options.merge(options))
+        if InvisibleCaptcha.honeypot_enabled
+          concat label_tag(build_label_name(honeypot, scope), label)
+          concat text_field_tag(build_input_name(honeypot, scope), nil, default_honeypot_options.merge(options))
+        end
         if InvisibleCaptcha.spinner_enabled
           concat hidden_field_tag("spinner", session[:invisible_captcha_spinner], id: nil)
         end
       end
-    end
-
-    def build_spinner_only
-      return ''.html_safe unless InvisibleCaptcha.spinner_enabled
-
-      hidden_field_tag('spinner', session[:invisible_captcha_spinner], id: nil)
     end
 
     def visibility_css(css_class, options)

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -38,6 +38,8 @@ module InvisibleCaptcha
         honeypot = nil
       end
 
+      return build_spinner_only unless InvisibleCaptcha.honeypot_enabled
+
       honeypot  = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
       label     = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
       css_class = "#{honeypot}_#{Time.zone.now.to_i}"
@@ -56,6 +58,12 @@ module InvisibleCaptcha
           concat hidden_field_tag("spinner", session[:invisible_captcha_spinner], id: nil)
         end
       end
+    end
+
+    def build_spinner_only
+      return ''.html_safe unless InvisibleCaptcha.spinner_enabled
+
+      hidden_field_tag('spinner', session[:invisible_captcha_spinner], id: nil)
     end
 
     def visibility_css(css_class, options)

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -33,12 +33,13 @@ module InvisibleCaptcha
     private
 
     def build_invisible_captcha(honeypot = nil, scope = nil, options = {})
-      if honeypot.is_a?(Hash)
-        options = honeypot
-        honeypot = nil
-      end
-
+      return '' unless InvisibleCaptcha.honeypot_enabled || InvisibleCaptcha.spinner_enabled
+      
       if InvisibleCaptcha.honeypot_enabled
+        if honeypot.is_a?(Hash)
+          options = honeypot
+          honeypot = nil
+        end
         honeypot  = honeypot ? honeypot.to_s : InvisibleCaptcha.get_honeypot
         label     = options.delete(:sentence_for_humans) || InvisibleCaptcha.sentence_for_humans
         css_class = "#{honeypot}_#{Time.zone.now.to_i}"

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -223,6 +223,24 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
     end
   end
 
+  context 'with honeypot_enabled = false' do
+    before(:each) do
+      InvisibleCaptcha.honeypot_enabled = false
+      session[:invisible_captcha_timestamp] = Time.zone.now.iso8601
+
+      # Wait for valid submission
+      sleep InvisibleCaptcha.timestamp_threshold
+    end
+
+    after(:each) { InvisibleCaptcha.honeypot_enabled = true }
+
+    it 'passes even when the honeypot field is filled' do
+      post :create, params: { topic: { subtitle: 'spam-value', title: 'foo' } }
+
+      expect(response.body).to be_present
+    end
+  end
+
   context 'spinner attribute' do
     before(:each) do
       InvisibleCaptcha.spinner_enabled = true

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -75,6 +75,31 @@ RSpec.describe InvisibleCaptcha::ViewHelpers, type: :helper do
     end
   end
 
+  context "should have honeypot field" do
+    it 'that exists by default, honeypot_enabled is true' do
+      InvisibleCaptcha.honeypot_enabled = true
+      InvisibleCaptcha.honeypots = [:foo_id]
+      expect(invisible_captcha).to match(/name="foo_id"/)
+    end
+
+    it 'that does not exist if honeypot_enabled is false' do
+      InvisibleCaptcha.honeypot_enabled = false
+      expect(invisible_captcha).not_to match(/type="text"/)
+    end
+
+    it 'still renders the spinner if honeypot_enabled is false and spinner_enabled is true' do
+      InvisibleCaptcha.honeypot_enabled = false
+      InvisibleCaptcha.spinner_enabled = true
+      expect(invisible_captcha).to match(/name="spinner"/)
+    end
+
+    it 'renders nothing if both honeypot_enabled and spinner_enabled are false' do
+      InvisibleCaptcha.honeypot_enabled = false
+      InvisibleCaptcha.spinner_enabled = false
+      expect(invisible_captcha).to eq('')
+    end
+  end
+
   it 'should set spam timestamp' do
     invisible_captcha
     expect(session[:invisible_captcha_timestamp]).to eq(Time.zone.now.iso8601)


### PR DESCRIPTION
## Summary

Adds `honeypot_enabled` config, mirroring `spinner_enabled` / `timestamp_enabled`. Default `true` — no behavior change. When `false`, the view helper emits only the spinner field and `honeypot_spam?` short-circuits to `false`.

## Why

Password managers can autofill the hidden honeypot text input with unrelated saved values. The controller treats the submission as spam and the gem responds with `head(200)` — a blank white page with no flash. We saw real users blocked this way in production; 30-day audit on our app: 0 honeypot true positives, 7 false positives.

`honeypots = []` works as a workaround (controller iterates nothing; view falls back to a nameless input browsers can't submit) but still emits the wrapper `<div>` / `<style>` / `<label>` / `<input>` into the DOM, and isn't documented as a way to disable the feature.

## drawback

when the spinner is on and the honepot is off, we end up with markup like this:

```html
<div>
  <style media="screen">
    . {display:none;}
  </style>
  <input type="hidden" name="spinner" value="..." />
</div>
```

which works fine but has some invalid/irrelevant aspects to it

we could refactor things to generate nice output in all circumstances, it's a larger refator, but not very hard. i could do it if there is interest and you could give feedback and merge 1-2 precursor PRs as i make them.