### PR TITLE
Consume spinner token from session

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -76,7 +76,12 @@ module InvisibleCaptcha
     end
 
     def spinner_spam?
-      if InvisibleCaptcha.spinner_enabled && (params[:spinner].blank? || params[:spinner] != session[:invisible_captcha_spinner])
+      return false unless InvisibleCaptcha.spinner_enabled
+
+      spinner_value = params[:spinner]
+      session_value = session.delete(:invisible_captcha_spinner)
+
+      if spinner_value.blank? || spinner_value != session_value
         warn_spam("Spinner value mismatch")
         return true
       end

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -242,26 +242,38 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
   end
 
   context 'spinner attribute' do
+    let(:spinner_value) do
+      '32ab649161f9f6faeeb323746de1a25d'
+    end
+
+    let(:valid_params) do
+      { title: 'foobar', author: 'author', body: 'body that passes validation' }
+    end
+    
     before(:each) do
       InvisibleCaptcha.spinner_enabled = true
       InvisibleCaptcha.secret = 'secret'
       session[:invisible_captcha_timestamp] = Time.zone.now.iso8601
-      session[:invisible_captcha_spinner] = '32ab649161f9f6faeeb323746de1a25d'
+      session[:invisible_captcha_spinner] = spinner_value
 
       # Wait for valid submission
       sleep InvisibleCaptcha.timestamp_threshold
     end
 
     it 'fails with no spam, but mismatch of spinner' do
-      post :create,  params: { topic: { title: 'foo' }, spinner: 'mismatch' }
+      post :create, params: { topic: valid_params, spinner: spinner_value.reverse }
 
-      expect(response.body).to be_blank
+      expect(response).to have_http_status(:success)
+      expect(flash.notice).to be_blank
+      expect(session).not_to have_key(:invisible_captcha_spinner)
     end
 
     it 'passes with no spam and spinner match' do
-      post :create,  params: { topic: { title: 'foo' }, spinner: '32ab649161f9f6faeeb323746de1a25d' }
-
-      expect(response.body).to be_present
+      post :create, params: { topic: valid_params, spinner: spinner_value }
+      
+      expect(response).to have_http_status(:redirect)
+      expect(flash.notice).to be_present
+      expect(session).not_to have_key(:invisible_captcha_spinner)
     end
   end
 end


### PR DESCRIPTION
Currently, the `invisible_captcha_timestamp` is explicitly consumed and removed from the session during validation, but the `invisible_captcha_spinner` is only read.

While this doesn't impact failed/spam requests, it creates an issue on successful form submissions.
Because the `invisible_captcha_spinner` token is never deleted, it lingers in the user's session cookie indefinitely as stale data.