### PR TITLE
Upgrade spinner token comparison logic for hardened constant-time security

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -81,12 +81,16 @@ module InvisibleCaptcha
       spinner_value = params[:spinner]
       session_value = session.delete(:invisible_captcha_spinner)
 
-      if spinner_value.blank? || spinner_value != session_value
+      if spinner_value.blank? || !secure_compare(spinner_value, session_value)
         warn_spam("Spinner value mismatch")
         return true
       end
 
       false
+    end
+
+    def secure_compare(value, other_value)
+      ActiveSupport::SecurityUtils.secure_compare(value.to_s, other_value.to_s)
     end
 
     def honeypot_spam?(options = {})

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
+  include ActiveSupport::Testing::TimeHelpers
+
   render_views
 
   before(:each) do
@@ -43,7 +45,9 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
     end
 
     it 'fails if submission before timestamp_threshold' do
-      post :create, params: { topic: { title: 'foo' } }
+      freeze_time do
+        post :create, params: { topic: { title: 'foo' } }
+      end
 
       expect(response).to redirect_to 'http://test.host/topics'
       expect(flash[:error]).to eq(InvisibleCaptcha.timestamp_error_message)
@@ -53,7 +57,9 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
     end
 
     it 'allows a custom on_timestamp_spam callback' do
-      put :update, params: { id: 1, topic: { title: 'bar' } }
+      freeze_time do
+        put :update, params: { id: 1, topic: { title: 'bar' } }
+      end
 
       expect(response.status).to eq(204)
     end
@@ -66,9 +72,11 @@ RSpec.describe InvisibleCaptcha::ControllerExt, type: :controller do
         end
       end
 
-      expect { put :update, params: { id: 1, topic: { title: 'bar' } } }
-        .to change { session[:invisible_captcha_timestamp] }
-        .to be_present
+      freeze_time do
+        expect { put :update, params: { id: 1, topic: { title: 'bar' } } }
+          .to change { session[:invisible_captcha_timestamp] }
+          .to be_present
+      end
     end
 
     it 'runs on_spam callback if on_timestamp_spam callback is defined but passes' do

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe InvisibleCaptcha::ViewHelpers, type: :helper do
+  include ActiveSupport::Testing::TimeHelpers
+
   before(:each) do
     allow(InvisibleCaptcha).to receive(:css_strategy).and_return("display:none;")
     allow_any_instance_of(ActionDispatch::ContentSecurityPolicy::Request).to receive(:content_security_policy_nonce).and_return('123')
@@ -101,8 +103,10 @@ RSpec.describe InvisibleCaptcha::ViewHelpers, type: :helper do
   end
 
   it 'should set spam timestamp' do
-    invisible_captcha
-    expect(session[:invisible_captcha_timestamp]).to eq(Time.zone.now.iso8601)
+    freeze_time do
+      invisible_captcha
+      expect(session[:invisible_captcha_timestamp]).to eq(Time.zone.now.iso8601)
+    end
   end
 
   context 'injectable_styles option' do


### PR DESCRIPTION
- Replaced standard string comparison with a secure, constant-time comparison to prevent potential timing attacks.
While the practical risk here is low, upgrading to a constant-time comparison is a zero-cost fix that aligns with standard Rails security conventions.
- Fix flaky timestamp-threshold specs. Relied on real elapsed time staying under the 1s threshold.