### PR TITLE
Add clear invisible captcha session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spec/dummy/log/*.log
 spec/dummy/tmp/
 .byebug_history
 .DS_Store
+/coverage/

--- a/README.md
+++ b/README.md
@@ -169,6 +169,37 @@ The `invisible_captcha` method accepts some options:
 - `timestamp_threshold`: custom threshold per controller/action. Overrides the global value for `InvisibleCaptcha.timestamp_threshold`.
 - `prepend`: the spam detection will run in a `prepend_before_action` if `prepend: true`, otherwise will run in a `before_action`.
 
+### Clearing invisible_captcha session data
+
+`invisible_captcha` stores a couple of values in the session (timestamp and/or spinner token) when the form is rendered.
+They get cleaned up automatically once the guarded action runs.
+But if a form is rendered in one flow and the user completes a *different* action that isn't guarded by `invisible_captcha`, those keys are never consumed and stay in the session.
+This can happen when:
+
+- a sign-up form sets these session keys, but the user logs in instead.
+- a page renders a password-based login form alongside an OmniAuth/OAuth button (e.g.: "Sign in with Google").
+  The form sets the session keys on render, but the user authenticates via the OAuth callback action instead, which never touches `invisible_captcha`.
+
+If you want to clear them explicitly, call `clear_invisible_captcha_session` at the exact point where you know the alternate flow succeeded:
+
+```ruby
+class SessionsController < ApplicationController
+  def create
+    if @user = User.authenticate(params)
+      sign_in(@user)
+      clear_invisible_captcha_session
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+end
+```
+
+Apply the same pattern in an OmniAuth callback controller's success branch.
+
+**Don't** wire this up as a `before_action`/`after_action`. There is no reliable, generic way to detect "the action succeeded" from a filter (a failed login might re-render the same action instead of redirecting, which would wipe out the freshly-rendered form's session values before the user gets a chance to resubmit). Call it explicitly, only on the success path you control.
+
 ### View helpers options:
 
 Using the view/form helper you can override some defaults for the given instance. Actually, it allows to change:

--- a/lib/invisible_captcha.rb
+++ b/lib/invisible_captcha.rb
@@ -7,6 +7,9 @@ require 'invisible_captcha/form_helpers'
 require 'invisible_captcha/railtie'
 
 module InvisibleCaptcha
+  SESSION_TIMESTAMP_KEY = :invisible_captcha_timestamp
+  SESSION_SPINNER_KEY = :invisible_captcha_spinner
+
   class << self
     attr_writer :sentence_for_humans,
                 :timestamp_error_message

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -18,6 +18,11 @@ module InvisibleCaptcha
 
     private
 
+    def clear_invisible_captcha_session
+      session.delete(:invisible_captcha_timestamp)
+      session.delete(:invisible_captcha_spinner)
+    end
+
     def detect_spam(options = {})
       if timestamp_spam?(options)
         on_timestamp_spam(options)

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -19,8 +19,8 @@ module InvisibleCaptcha
     private
 
     def clear_invisible_captcha_session
-      session.delete(:invisible_captcha_timestamp)
-      session.delete(:invisible_captcha_spinner)
+      session.delete(InvisibleCaptcha::SESSION_TIMESTAMP_KEY)
+      session.delete(InvisibleCaptcha::SESSION_SPINNER_KEY)
     end
 
     def detect_spam(options = {})
@@ -60,7 +60,7 @@ module InvisibleCaptcha
 
       return false unless enabled
 
-      timestamp = session.delete(:invisible_captcha_timestamp)
+      timestamp = session.delete(InvisibleCaptcha::SESSION_TIMESTAMP_KEY)
 
       # Consider as spam if timestamp not in session, cause that means the form was not fetched at all
       unless timestamp
@@ -84,7 +84,7 @@ module InvisibleCaptcha
       return false unless InvisibleCaptcha.spinner_enabled
 
       spinner_value = params[:spinner]
-      session_value = session.delete(:invisible_captcha_spinner)
+      session_value = session.delete(InvisibleCaptcha::SESSION_SPINNER_KEY)
 
       if spinner_value.blank? || !secure_compare(spinner_value, session_value)
         warn_spam("Spinner value mismatch")

--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -16,12 +16,12 @@ module InvisibleCaptcha
       end
     end
 
-    private
-
     def clear_invisible_captcha_session
       session.delete(InvisibleCaptcha::SESSION_TIMESTAMP_KEY)
       session.delete(InvisibleCaptcha::SESSION_SPINNER_KEY)
     end
+
+    private
 
     def detect_spam(options = {})
       if timestamp_spam?(options)

--- a/lib/invisible_captcha/view_helpers.rb
+++ b/lib/invisible_captcha/view_helpers.rb
@@ -14,11 +14,11 @@ module InvisibleCaptcha
       @captcha_ocurrences += 1
 
       if InvisibleCaptcha.timestamp_enabled || InvisibleCaptcha.spinner_enabled
-        session[:invisible_captcha_timestamp] = Time.zone.now.iso8601
+        session[InvisibleCaptcha::SESSION_TIMESTAMP_KEY] = Time.zone.now.iso8601
       end
 
       if InvisibleCaptcha.spinner_enabled && @captcha_ocurrences == 1
-        session[:invisible_captcha_spinner] = InvisibleCaptcha.encode("#{session[:invisible_captcha_timestamp]}-#{request.remote_ip}")
+        session[InvisibleCaptcha::SESSION_SPINNER_KEY] = InvisibleCaptcha.encode("#{session[InvisibleCaptcha::SESSION_TIMESTAMP_KEY]}-#{request.remote_ip}")
       end
 
       build_invisible_captcha(honeypot, scope, options)
@@ -58,7 +58,7 @@ module InvisibleCaptcha
           concat text_field_tag(build_input_name(honeypot, scope), nil, default_honeypot_options.merge(options))
         end
         if InvisibleCaptcha.spinner_enabled
-          concat hidden_field_tag("spinner", session[:invisible_captcha_spinner], id: nil)
+          concat hidden_field_tag("spinner", session[InvisibleCaptcha::SESSION_SPINNER_KEY], id: nil)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,9 @@ if ENV['CI']
   require 'simplecov-cobertura'
   SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/spec/'
+end
 
 require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require 'rspec/rails'


### PR DESCRIPTION
- Add `clear_invisible_captcha_session` to manually clear stale session data when a rendered form's action never runs (e.g.: OAuth login instead of the guarded form).
- Move session key strings into constants to stop typo drift between files.
- Ignore coverage output and exclude specs from the coverage report.